### PR TITLE
refactor: ToolContext + TOOL_REGISTRY (Phase 1 of HTTP transport)

### DIFF
--- a/docs/superpowers/plans/2026-05-12-phase-1-tool-context-refactor.md
+++ b/docs/superpowers/plans/2026-05-12-phase-1-tool-context-refactor.md
@@ -972,7 +972,7 @@ Run:
 ```bash
 .venv/bin/python3 -c "from illumio_mcp.tools import TOOL_REGISTRY, TOOL_HANDLERS; print(f'{len(TOOL_REGISTRY)} tools, {len(TOOL_HANDLERS)} handlers')"
 ```
-Expected: `45 tools, 45 handlers`
+Expected: `43 tools, 43 handlers`
 
 - [ ] **Step 3: Commit**
 
@@ -1171,7 +1171,7 @@ def test_ringfence_batch_requires_confirm():
 def test_count_matches_expected():
     """Sanity check: tool count is stable. Bump this when you intentionally
     add or remove a tool."""
-    assert len(TOOL_REGISTRY) == 45, \
+    assert len(TOOL_REGISTRY) == 43, \
         f"Tool count drifted to {len(TOOL_REGISTRY)}; update this test if intentional"
 ```
 

--- a/src/illumio_mcp/context.py
+++ b/src/illumio_mcp/context.py
@@ -1,0 +1,20 @@
+"""ToolContext: the per-call object every tool handler receives.
+
+In Phase 1 (this refactor) it carries only the PCE client and a flag indicating
+whether we're running under stdio (the default today). Phases 2 and 3 will add
+user identity, role, scope, and request-id fields. Existing call sites should
+not break when those are added — they all have defaults.
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class ToolContext:
+    """Everything a tool handler needs that is *not* the tool's own arguments.
+
+    Build one per request (HTTP) or once at startup (stdio) and pass it to
+    every handler. Handlers MUST read PCE from `ctx.pce` and never call
+    process-global PCE accessors.
+    """
+    pce: object  # illumio.PolicyComputeEngine, but kept untyped to avoid import here
+    is_stdio: bool

--- a/src/illumio_mcp/pce.py
+++ b/src/illumio_mcp/pce.py
@@ -1,8 +1,27 @@
+"""PCE client construction.
+
+Two entry points:
+
+- `build_pce_for(creds)` — pure builder. Returns a fresh PolicyComputeEngine
+  for the given credentials. This is what HTTP/per-user mode (Phase 3) uses.
+- `get_pce_from_env()` — process-wide singleton built from env vars. This is
+  what stdio mode uses. `get_pce()` is kept as an alias for back-compat with
+  handlers that haven't been migrated yet (they will be in Tasks 4–14).
+
+PCE_ORG_ID and `run_sync` are re-exported from this module to preserve the
+existing import surface used by tools/infra.py, tools/containers.py, and
+tools/traffic.py.
+"""
 import asyncio
 import os
 import urllib3
+from dataclasses import dataclass
+from typing import Optional
+
 from illumio import PolicyComputeEngine
 
+# Module-level env reads kept for back-compat with tools/infra.py and
+# tools/containers.py which import PCE_ORG_ID directly.
 PCE_HOST = os.getenv("PCE_HOST")
 PCE_PORT = os.getenv("PCE_PORT")
 PCE_ORG_ID = os.getenv("PCE_ORG_ID")
@@ -13,16 +32,57 @@ PCE_TLS_VERIFY = os.getenv("PCE_TLS_VERIFY", "true").lower() not in ("false", "0
 if not PCE_TLS_VERIFY:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-_pce_instance = None
+
+@dataclass(frozen=True)
+class PCECredentials:
+    host: str
+    port: int
+    org_id: int
+    api_key: str
+    api_secret: str
+    tls_verify: bool = True
 
 
+def build_pce_for(creds: PCECredentials) -> PolicyComputeEngine:
+    """Construct a fresh PolicyComputeEngine. Does NOT cache.
+
+    Each call returns a new client. This is required for per-user PCE access
+    in Phase 3 — the same process talks to PCE as multiple users concurrently.
+    """
+    pce = PolicyComputeEngine(creds.host, port=creds.port, org_id=creds.org_id)
+    pce.set_credentials(creds.api_key, creds.api_secret)
+    pce._session.verify = creds.tls_verify
+    return pce
+
+
+_stdio_singleton: Optional[PolicyComputeEngine] = None
+
+
+def get_pce_from_env() -> PolicyComputeEngine:
+    """Return a process-wide PCE client built from PCE_* env vars.
+
+    Used by stdio mode. Cached so we reuse the underlying HTTP session.
+    """
+    global _stdio_singleton
+    if _stdio_singleton is None:
+        creds = PCECredentials(
+            host=os.getenv("PCE_HOST"),
+            port=int(os.getenv("PCE_PORT")) if os.getenv("PCE_PORT") else None,
+            org_id=int(os.getenv("PCE_ORG_ID")) if os.getenv("PCE_ORG_ID") else None,
+            api_key=os.getenv("API_KEY"),
+            api_secret=os.getenv("API_SECRET"),
+            tls_verify=PCE_TLS_VERIFY,
+        )
+        _stdio_singleton = build_pce_for(creds)
+    return _stdio_singleton
+
+
+# Back-compat alias. Existing handler code calls `get_pce()`. Once Tasks 4–14
+# convert handlers to read from `ctx.pce`, this alias is no longer used by
+# handlers but is kept so any external callers (e.g. tests, scripts) keep
+# working. Removing it can be a follow-up cleanup.
 def get_pce() -> PolicyComputeEngine:
-    global _pce_instance
-    if _pce_instance is None:
-        _pce_instance = PolicyComputeEngine(PCE_HOST, port=PCE_PORT, org_id=PCE_ORG_ID)
-        _pce_instance.set_credentials(API_KEY, API_SECRET)
-        _pce_instance._session.verify = PCE_TLS_VERIFY
-    return _pce_instance
+    return get_pce_from_env()
 
 
 async def run_sync(func, *args, **kwargs):

--- a/src/illumio_mcp/registry.py
+++ b/src/illumio_mcp/registry.py
@@ -1,0 +1,48 @@
+"""ToolSpec: per-tool metadata used by the dispatcher and Phase 3 authz.
+
+In Phase 1 this metadata is recorded but only one consumer reads it (a CI test
+that asserts every tool has explicit role assignment). Phase 3 authz middleware
+will read `roles`, `mutating`, `requires_confirm`, and `unscopable` to decide
+whether to allow a call.
+"""
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+Role = Literal["reader", "operator", "admin"]
+READER: Role = "reader"
+OPERATOR: Role = "operator"
+ADMIN: Role = "admin"
+ALL_ROLES: frozenset[Role] = frozenset({READER, OPERATOR, ADMIN})
+
+_VALID_ROLES = ALL_ROLES
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Metadata for one MCP tool.
+
+    Attributes:
+        handler: The handler callable. Signature: (ctx, arguments) -> list.
+        roles: Set of roles permitted to call this tool. Must be non-empty.
+        mutating: True if the tool changes PCE state (create/update/delete/provision).
+        requires_confirm: True if a step-up confirm token is required (Phase 3).
+            Implies mutating=True.
+        unscopable: True if the tool returns PCE-wide data that cannot be safely
+            filtered to a user's allowed label scopes (Phase 3).
+    """
+    handler: Callable
+    roles: frozenset[Role] | set[Role]
+    mutating: bool = False
+    requires_confirm: bool = False
+    unscopable: bool = False
+
+    def __post_init__(self):
+        if not self.roles:
+            raise ValueError("ToolSpec must have at least one role (default-deny)")
+        unknown = set(self.roles) - _VALID_ROLES
+        if unknown:
+            raise ValueError(f"ToolSpec has unknown role(s): {sorted(unknown)}")
+        if self.requires_confirm and not self.mutating:
+            raise ValueError("requires_confirm is only valid for mutating tools")
+        # Freeze the role set so it can't be mutated post-construction
+        object.__setattr__(self, "roles", frozenset(self.roles))

--- a/src/illumio_mcp/server.py
+++ b/src/illumio_mcp/server.py
@@ -10,7 +10,9 @@ import mcp.server.stdio
 import dotenv
 from pathlib import Path
 
-from .tools import TOOL_HANDLERS
+from .context import ToolContext
+from .pce import get_pce_from_env
+from .tools import TOOL_REGISTRY
 
 
 def setup_logging():
@@ -46,6 +48,27 @@ logger = setup_logging()
 logger.debug("Loading environment variables")
 
 dotenv.load_dotenv()
+
+
+def _build_stdio_context() -> ToolContext:
+    """Build the single ToolContext used for the lifetime of the stdio process.
+
+    Stdio mode has one user (the operator who launched the process) and one PCE
+    (built from PCE_* env vars). The ToolContext is created lazily on first use
+    so that test setups can override env before the PCE is constructed.
+    """
+    return ToolContext(pce=get_pce_from_env(), is_stdio=True)
+
+
+_stdio_ctx: ToolContext | None = None
+
+
+def _get_stdio_context() -> ToolContext:
+    global _stdio_ctx
+    if _stdio_ctx is None:
+        _stdio_ctx = _build_stdio_context()
+    return _stdio_ctx
+
 
 server = Server("illumio-mcp")
 logging.debug("Server initialized")
@@ -3121,12 +3144,13 @@ rollouts. Returns a ranked list with scores, classification tiers, and connectiv
 @server.call_tool()
 async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
     logger.debug(f"Tool called: {name} with arguments: {arguments}")
-    handler = TOOL_HANDLERS.get(name)
-    if handler is None:
+    spec = TOOL_REGISTRY.get(name)
+    if spec is None:
         raise ValueError(f"Unknown tool: {name}")
+    ctx = _get_stdio_context()
     try:
         t0 = time.monotonic()
-        result = await asyncio.to_thread(handler, arguments or {})
+        result = await asyncio.to_thread(spec.handler, ctx, arguments or {})
         elapsed = time.monotonic() - t0
         logger.info(f"Tool {name} completed in {elapsed:.2f}s")
         return result

--- a/src/illumio_mcp/tools/__init__.py
+++ b/src/illumio_mcp/tools/__init__.py
@@ -1,3 +1,14 @@
+"""Tool registry. Maps MCP tool names to ToolSpec (handler + authz metadata).
+
+Add a new tool by:
+  1. Implementing `def handle_X(ctx, arguments) -> list:` in the right module.
+  2. Adding a ToolSpec entry below with explicit `roles=`. Default-deny: a tool
+     with no roles will fail at import time.
+"""
+from typing import Callable
+
+from ..registry import ToolSpec, READER, OPERATOR, ADMIN, ALL_ROLES
+
 from .workloads import (
     handle_get_workloads,
     handle_create_workload,
@@ -64,59 +75,71 @@ from .infra import (
     handle_get_pairing_profiles,
 )
 
-TOOL_HANDLERS = {
+
+_OP_ADMIN = frozenset({OPERATOR, ADMIN})
+_ADMIN_ONLY = frozenset({ADMIN})
+
+
+TOOL_REGISTRY: dict[str, ToolSpec] = {
     # Workloads
-    "get-workloads": handle_get_workloads,
-    "create-workload": handle_create_workload,
-    "update-workload": handle_update_workload,
-    "delete-workload": handle_delete_workload,
+    "get-workloads":              ToolSpec(handle_get_workloads,            roles=ALL_ROLES),
+    "create-workload":            ToolSpec(handle_create_workload,          roles=_OP_ADMIN, mutating=True),
+    "update-workload":            ToolSpec(handle_update_workload,          roles=_OP_ADMIN, mutating=True),
+    "delete-workload":            ToolSpec(handle_delete_workload,          roles=_OP_ADMIN, mutating=True),
     # Labels
-    "get-labels": handle_get_labels,
-    "create-label": handle_create_label,
-    "update-label": handle_update_label,
-    "delete-label": handle_delete_label,
+    "get-labels":                 ToolSpec(handle_get_labels,               roles=ALL_ROLES),
+    "create-label":               ToolSpec(handle_create_label,             roles=_OP_ADMIN, mutating=True),
+    "update-label":               ToolSpec(handle_update_label,             roles=_OP_ADMIN, mutating=True),
+    "delete-label":               ToolSpec(handle_delete_label,             roles=_OP_ADMIN, mutating=True),
     # Services
-    "get-services": handle_get_services,
-    "create-service": handle_create_service,
-    "update-service": handle_update_service,
-    "delete-service": handle_delete_service,
+    "get-services":               ToolSpec(handle_get_services,             roles=ALL_ROLES),
+    "create-service":             ToolSpec(handle_create_service,           roles=_OP_ADMIN, mutating=True),
+    "update-service":             ToolSpec(handle_update_service,           roles=_OP_ADMIN, mutating=True),
+    "delete-service":             ToolSpec(handle_delete_service,           roles=_OP_ADMIN, mutating=True),
     # IP Lists
-    "get-iplists": handle_get_iplists,
-    "create-iplist": handle_create_iplist,
-    "update-iplist": handle_update_iplist,
-    "delete-iplist": handle_delete_iplist,
-    # Rulesets
-    "get-rulesets": handle_get_rulesets,
-    "create-ruleset": handle_create_ruleset,
-    "update-ruleset": handle_update_ruleset,
-    "delete-ruleset": handle_delete_ruleset,
-    "provision-policy": handle_provision_policy,
+    "get-iplists":                ToolSpec(handle_get_iplists,              roles=ALL_ROLES),
+    "create-iplist":              ToolSpec(handle_create_iplist,            roles=_OP_ADMIN, mutating=True),
+    "update-iplist":              ToolSpec(handle_update_iplist,            roles=_OP_ADMIN, mutating=True),
+    "delete-iplist":              ToolSpec(handle_delete_iplist,            roles=_OP_ADMIN, mutating=True),
+    # Rulesets + provisioning
+    "get-rulesets":               ToolSpec(handle_get_rulesets,             roles=ALL_ROLES),
+    "create-ruleset":             ToolSpec(handle_create_ruleset,           roles=_OP_ADMIN, mutating=True),
+    "update-ruleset":             ToolSpec(handle_update_ruleset,           roles=_OP_ADMIN, mutating=True),
+    "delete-ruleset":             ToolSpec(handle_delete_ruleset,           roles=_OP_ADMIN, mutating=True),
+    "provision-policy":           ToolSpec(handle_provision_policy,         roles=_ADMIN_ONLY, mutating=True, requires_confirm=True),
     # Deny Rules
-    "create-deny-rule": handle_create_deny_rule,
-    "update-deny-rule": handle_update_deny_rule,
-    "delete-deny-rule": handle_delete_deny_rule,
+    "create-deny-rule":           ToolSpec(handle_create_deny_rule,         roles=_OP_ADMIN, mutating=True),
+    "update-deny-rule":           ToolSpec(handle_update_deny_rule,         roles=_OP_ADMIN, mutating=True),
+    "delete-deny-rule":           ToolSpec(handle_delete_deny_rule,         roles=_OP_ADMIN, mutating=True),
     # Traffic
-    "get-traffic-flows": handle_get_traffic_flows,
-    "get-traffic-flows-summary": handle_get_traffic_flows_summary,
-    "find-unmanaged-traffic": handle_find_unmanaged_traffic,
-    # Policy
-    "compliance-check": handle_compliance_check,
-    "enforcement-readiness": handle_enforcement_readiness,
-    "get-policy-coverage-report": handle_get_policy_coverage_report,
-    "compare-draft-active": handle_compare_draft_active,
-    "get-workload-enforcement-status": handle_get_workload_enforcement_status,
+    "get-traffic-flows":          ToolSpec(handle_get_traffic_flows,        roles=ALL_ROLES),
+    "get-traffic-flows-summary":  ToolSpec(handle_get_traffic_flows_summary,roles=ALL_ROLES),
+    "find-unmanaged-traffic":     ToolSpec(handle_find_unmanaged_traffic,   roles=ALL_ROLES, unscopable=True),
+    # Policy reports (PCE-wide; not safely scopable)
+    "compliance-check":           ToolSpec(handle_compliance_check,         roles=ALL_ROLES, unscopable=True),
+    "enforcement-readiness":      ToolSpec(handle_enforcement_readiness,    roles=ALL_ROLES, unscopable=True),
+    "get-policy-coverage-report": ToolSpec(handle_get_policy_coverage_report,roles=ALL_ROLES, unscopable=True),
+    "compare-draft-active":       ToolSpec(handle_compare_draft_active,     roles=ALL_ROLES, unscopable=True),
+    "get-workload-enforcement-status": ToolSpec(handle_get_workload_enforcement_status, roles=ALL_ROLES),
     # Ringfence
-    "create-ringfence": handle_create_ringfence,
-    "ringfence-batch": handle_ringfence_batch,
-    "identify-infrastructure-services": handle_identify_infrastructure_services,
-    "detect-lateral-movement-paths": handle_detect_lateral_movement_paths,
+    "create-ringfence":           ToolSpec(handle_create_ringfence,         roles=_OP_ADMIN, mutating=True),
+    "ringfence-batch":            ToolSpec(handle_ringfence_batch,          roles=_ADMIN_ONLY, mutating=True, requires_confirm=True),
+    "identify-infrastructure-services": ToolSpec(handle_identify_infrastructure_services, roles=ALL_ROLES, unscopable=True),
+    "detect-lateral-movement-paths":    ToolSpec(handle_detect_lateral_movement_paths,    roles=ALL_ROLES, unscopable=True),
     # Containers
-    "get-container-clusters": handle_get_container_clusters,
-    "get-container-workload-profiles": handle_get_container_workload_profiles,
-    "update-container-workload-profile": handle_update_container_workload_profile,
-    "get-kubernetes-workloads": handle_get_kubernetes_workloads,
+    "get-container-clusters":     ToolSpec(handle_get_container_clusters,   roles=ALL_ROLES),
+    "get-container-workload-profiles": ToolSpec(handle_get_container_workload_profiles, roles=ALL_ROLES),
+    "update-container-workload-profile": ToolSpec(handle_update_container_workload_profile, roles=_OP_ADMIN, mutating=True),
+    "get-kubernetes-workloads":   ToolSpec(handle_get_kubernetes_workloads, roles=ALL_ROLES),
     # Infrastructure
-    "check-pce-connection": handle_check_pce_connection,
-    "get-events": handle_get_events,
-    "get-pairing-profiles": handle_get_pairing_profiles,
+    "check-pce-connection":       ToolSpec(handle_check_pce_connection,     roles=ALL_ROLES),
+    "get-events":                 ToolSpec(handle_get_events,               roles=ALL_ROLES),
+    "get-pairing-profiles":       ToolSpec(handle_get_pairing_profiles,     roles=ALL_ROLES),
 }
+
+
+# Back-compat: derived map of name → callable. Some external code (and the
+# previous server.py) referenced TOOL_HANDLERS directly. After Task 16 this is
+# no longer used internally; kept as a derived export to avoid breaking any
+# downstream importers.
+TOOL_HANDLERS: dict[str, Callable] = {name: spec.handler for name, spec in TOOL_REGISTRY.items()}

--- a/src/illumio_mcp/tools/containers.py
+++ b/src/illumio_mcp/tools/containers.py
@@ -1,19 +1,19 @@
 import json
 import logging
 import mcp.types as types
-from ..pce import get_pce, PCE_ORG_ID
+from ..pce import PCE_ORG_ID
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_get_container_workload_profiles(arguments: dict) -> list:
+def handle_get_container_workload_profiles(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET CONTAINER WORKLOAD PROFILES CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         cluster_href = arguments.get("cluster_href")
 
@@ -66,14 +66,14 @@ def handle_get_container_workload_profiles(arguments: dict) -> list:
             return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_update_container_workload_profile(arguments: dict) -> list:
+def handle_update_container_workload_profile(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("UPDATE CONTAINER WORKLOAD PROFILE CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         profile_href = arguments["profile_href"]
         payload = {}
@@ -97,14 +97,14 @@ def handle_update_container_workload_profile(arguments: dict) -> list:
             return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_get_kubernetes_workloads(arguments: dict) -> list:
+def handle_get_kubernetes_workloads(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET KUBERNETES WORKLOADS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {"max_results": arguments.get("max_results", 500)}
         if arguments.get("namespace"):
@@ -143,14 +143,14 @@ def handle_get_kubernetes_workloads(arguments: dict) -> list:
             return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_get_container_clusters(arguments: dict) -> list:
+def handle_get_container_clusters(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET CONTAINER CLUSTERS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {"max_results": arguments.get("max_results", 50)}
         if arguments.get("name"):

--- a/src/illumio_mcp/tools/deny_rules.py
+++ b/src/illumio_mcp/tools/deny_rules.py
@@ -1,19 +1,18 @@
 import json
 import logging
 import mcp.types as types
-from ..pce import get_pce
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_create_deny_rule(arguments: dict) -> list:
+def handle_create_deny_rule(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("CREATE DENY RULE CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         # Build label maps
         label_href_map = {}
@@ -150,11 +149,11 @@ def handle_create_deny_rule(arguments: dict) -> list:
                 text=json.dumps({"error": error_msg}, indent=2)
             )]
 
-def handle_update_deny_rule(arguments: dict) -> list:
+def handle_update_deny_rule(ctx, arguments: dict) -> list:
     logger.debug(f"UPDATE DENY RULE CALLED with arguments: {json.dumps(arguments, indent=2)}")
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         href = arguments["href"]
         if '/active/' in href:
@@ -227,11 +226,11 @@ def handle_update_deny_rule(arguments: dict) -> list:
             return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_delete_deny_rule(arguments: dict) -> list:
+def handle_delete_deny_rule(ctx, arguments: dict) -> list:
     logger.debug(f"DELETE DENY RULE CALLED with arguments: {json.dumps(arguments, indent=2)}")
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         href = arguments["href"]
         if '/active/' in href:

--- a/src/illumio_mcp/tools/infra.py
+++ b/src/illumio_mcp/tools/infra.py
@@ -1,15 +1,15 @@
 import json
 import logging
 import mcp.types as types
-from ..pce import get_pce, PCE_ORG_ID
+from ..pce import PCE_ORG_ID
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_check_pce_connection(arguments: dict) -> list:
+def handle_check_pce_connection(ctx, arguments: dict) -> list:
     logger.debug("Initializing PCE connection")
     try:
-        pce = get_pce()
+        pce = ctx.pce
         connection_status = pce.check_connection()
         return [types.TextContent(
             type="text",
@@ -24,14 +24,14 @@ def handle_check_pce_connection(arguments: dict) -> list:
         )]
 
 
-def handle_get_events(arguments: dict) -> list:
+def handle_get_events(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET EVENTS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {}
         for param in ['event_type', 'severity', 'status', 'max_results', 'created_by']:
@@ -77,14 +77,14 @@ def handle_get_events(arguments: dict) -> list:
         )]
 
 
-def handle_get_pairing_profiles(arguments: dict) -> list:
+def handle_get_pairing_profiles(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET PAIRING PROFILES CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {"max_results": arguments.get("max_results", 50)}
         if arguments.get("name"):

--- a/src/illumio_mcp/tools/iplists.py
+++ b/src/illumio_mcp/tools/iplists.py
@@ -1,15 +1,14 @@
 import json
 import logging
 import mcp.types as types
-from ..pce import get_pce
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_get_iplists(arguments: dict) -> list:
+def handle_get_iplists(ctx, arguments: dict) -> list:
     logger.debug(f"GET IP LISTS CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {"max_results": arguments.get("max_results", 10000)}
         for param in ['name', 'description', 'fqdn', 'ip_address']:
@@ -41,7 +40,7 @@ def handle_get_iplists(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}))]
 
 
-def handle_create_iplist(arguments: dict) -> list:
+def handle_create_iplist(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("CREATE IP LIST CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -49,7 +48,7 @@ def handle_create_iplist(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # Check if IP List already exists
         logger.debug(f"Checking if IP List '{arguments['name']}' already exists...")
@@ -129,7 +128,7 @@ def handle_create_iplist(arguments: dict) -> list:
         )]
 
 
-def handle_update_iplist(arguments: dict) -> list:
+def handle_update_iplist(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("UPDATE IP LIST CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -137,7 +136,7 @@ def handle_update_iplist(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find the IP List
         iplist = None
@@ -230,7 +229,7 @@ def handle_update_iplist(arguments: dict) -> list:
         )]
 
 
-def handle_delete_iplist(arguments: dict) -> list:
+def handle_delete_iplist(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("DELETE IP LIST CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -238,7 +237,7 @@ def handle_delete_iplist(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find the IP List
         iplist = None

--- a/src/illumio_mcp/tools/labels.py
+++ b/src/illumio_mcp/tools/labels.py
@@ -2,15 +2,14 @@ import json
 import logging
 import mcp.types as types
 from illumio import Label
-from ..pce import get_pce
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_get_labels(arguments: dict) -> list:
+def handle_get_labels(ctx, arguments: dict) -> list:
     logger.debug("Initializing PCE connection")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {}
         if arguments.get('key'):
@@ -39,10 +38,10 @@ def handle_get_labels(arguments: dict) -> list:
         )]
 
 
-def handle_create_label(arguments: dict) -> list:
+def handle_create_label(ctx, arguments: dict) -> list:
     logger.debug(f"Creating label with key: {arguments['key']} and value: {arguments['value']}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
         label = Label(key=arguments['key'], value=arguments['value'])
         label = pce.labels.create(label)
         logger.debug(f"Label created with status: {label}")
@@ -59,10 +58,10 @@ def handle_create_label(arguments: dict) -> list:
         )]
 
 
-def handle_update_label(arguments: dict) -> list:
+def handle_update_label(ctx, arguments: dict) -> list:
     logger.debug("Initializing PCE connection")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         href = arguments.get("href")
         key = arguments.get("key")
@@ -127,10 +126,10 @@ def handle_update_label(arguments: dict) -> list:
         )]
 
 
-def handle_delete_label(arguments: dict) -> list:
+def handle_delete_label(ctx, arguments: dict) -> list:
     logger.debug(f"Deleting label with key: {arguments['key']} and value: {arguments['value']}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
         label = pce.labels.get(params={"key": arguments['key'], "value": arguments['value']})
         if label:
             pce.labels.delete(label[0])

--- a/src/illumio_mcp/tools/policy.py
+++ b/src/illumio_mcp/tools/policy.py
@@ -6,21 +6,20 @@ import mcp.types as types
 from illumio import TrafficQuery
 from illumio.explorer.trafficanalysis import TrafficQueryFilter
 from illumio.util.jsonutils import Reference
-from ..pce import get_pce
 from .traffic import to_dataframe
 from .constants import MCP_BUG_MAX_RESULTS
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_compliance_check(arguments: dict) -> list:
+def handle_compliance_check(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("COMPLIANCE CHECK CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         framework = arguments.get("framework", "general")
         app_name = arguments.get("app_name")
@@ -330,14 +329,14 @@ def handle_compliance_check(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_enforcement_readiness(arguments: dict) -> list:
+def handle_enforcement_readiness(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("ENFORCEMENT READINESS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         app_name = arguments["app_name"]
         env_name = arguments["env_name"]
@@ -516,14 +515,14 @@ def handle_enforcement_readiness(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_get_policy_coverage_report(arguments: dict) -> list:
+def handle_get_policy_coverage_report(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET POLICY COVERAGE REPORT CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         app_name = arguments["app_name"]
         env_name = arguments["env_name"]
@@ -652,14 +651,14 @@ def handle_get_policy_coverage_report(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_compare_draft_active(arguments: dict) -> list:
+def handle_compare_draft_active(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("COMPARE DRAFT ACTIVE CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         resource_type = arguments.get("resource_type", "all")
 
@@ -731,14 +730,14 @@ def handle_compare_draft_active(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_get_workload_enforcement_status(arguments: dict) -> list:
+def handle_get_workload_enforcement_status(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET WORKLOAD ENFORCEMENT STATUS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {"include": "labels", "max_results": 10000}
 

--- a/src/illumio_mcp/tools/policy.py
+++ b/src/illumio_mcp/tools/policy.py
@@ -169,7 +169,7 @@ def handle_compliance_check(ctx, arguments: dict) -> list:
 
         traffic_query = TrafficQuery.build(**query_kwargs)
         flows = pce.get_traffic_flows_async(query_name='compliance-check', traffic_query=traffic_query)
-        df = to_dataframe(flows)
+        df = to_dataframe(pce, flows)
 
         # Run compliance checks
         findings = []
@@ -397,8 +397,8 @@ def handle_enforcement_readiness(ctx, arguments: dict) -> list:
         )
         outbound_flows = pce.get_traffic_flows_async(query_name='readiness-outbound', traffic_query=traffic_query_out)
 
-        inbound_df = to_dataframe(inbound_flows)
-        outbound_df = to_dataframe(outbound_flows)
+        inbound_df = to_dataframe(pce, inbound_flows)
+        outbound_df = to_dataframe(pce, outbound_flows)
 
         # Analyze policy decisions
         policy_stats = {"allowed": 0, "potentially_blocked": 0, "blocked": 0, "unknown": 0}
@@ -568,8 +568,8 @@ def handle_get_policy_coverage_report(ctx, arguments: dict) -> list:
         )
         outbound_flows = pce.get_traffic_flows_async(query_name='coverage-outbound', traffic_query=traffic_query_out)
 
-        inbound_df = to_dataframe(inbound_flows)
-        outbound_df = to_dataframe(outbound_flows)
+        inbound_df = to_dataframe(pce, inbound_flows)
+        outbound_df = to_dataframe(pce, outbound_flows)
 
         # Analyze by policy decision
         def analyze_coverage(df, direction):

--- a/src/illumio_mcp/tools/ringfence.py
+++ b/src/illumio_mcp/tools/ringfence.py
@@ -6,21 +6,20 @@ import mcp.types as types
 from illumio import TrafficQuery, RuleSet, LabelSet, Rule, AMS, ServicePort
 from illumio.explorer.trafficanalysis import TrafficQueryFilter
 from illumio.util.jsonutils import Reference
-from ..pce import get_pce
 from .traffic import to_dataframe
 from .constants import MCP_BUG_MAX_RESULTS
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_create_ringfence(arguments: dict) -> list:
+def handle_create_ringfence(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("CREATE RINGFENCE CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         app_name = arguments["app_name"]
         env_name = arguments["env_name"]
@@ -511,7 +510,7 @@ def handle_create_ringfence(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_ringfence_batch(arguments: dict) -> list:
+def handle_ringfence_batch(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("RINGFENCE BATCH CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -525,7 +524,7 @@ def handle_ringfence_batch(arguments: dict) -> list:
 
         if auto_order:
             # Use infrastructure identification to order apps
-            infra_result = handle_identify_infrastructure_services({
+            infra_result = handle_identify_infrastructure_services(ctx, {
                 "lookback_days": lookback_days,
                 "top_n": 1000
             })
@@ -552,7 +551,7 @@ def handle_ringfence_batch(arguments: dict) -> list:
             }
 
             try:
-                rf_result = handle_create_ringfence(rf_args)
+                rf_result = handle_create_ringfence(ctx, rf_args)
                 result_data = json.loads(rf_result[0].text)
                 results.append({
                     "app": app["app_name"],
@@ -590,14 +589,14 @@ def handle_ringfence_batch(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_identify_infrastructure_services(arguments: dict) -> list:
+def handle_identify_infrastructure_services(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("IDENTIFY INFRASTRUCTURE SERVICES CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         lookback_days = arguments.get("lookback_days", 90)
         min_connections = arguments.get("min_connections", 1)
@@ -852,14 +851,14 @@ def handle_identify_infrastructure_services(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_detect_lateral_movement_paths(arguments: dict) -> list:
+def handle_detect_lateral_movement_paths(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("DETECT LATERAL MOVEMENT PATHS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         lookback_days = arguments.get("lookback_days", 30)
         max_hops = arguments.get("max_hops", 4)

--- a/src/illumio_mcp/tools/ringfence.py
+++ b/src/illumio_mcp/tools/ringfence.py
@@ -125,8 +125,8 @@ def handle_create_ringfence(ctx, arguments: dict) -> list:
         )
 
         # Step 5: Convert flows to dataframes and group by app+env
-        inbound_df = to_dataframe(inbound_flows)
-        outbound_df = to_dataframe(outbound_flows)
+        inbound_df = to_dataframe(pce, inbound_flows)
+        outbound_df = to_dataframe(pce, outbound_flows)
 
         remote_apps_inbound = {}  # key: (app_value, env_value) -> list of {port, proto, connections}
         remote_apps_outbound = {}
@@ -625,7 +625,7 @@ def handle_identify_infrastructure_services(ctx, arguments: dict) -> list:
                 "lookback_days": lookback_days
             }, indent=2))]
 
-        df = to_dataframe(flows)
+        df = to_dataframe(pce, flows)
 
         if df.empty or 'src_app' not in df.columns or 'dst_app' not in df.columns:
             return [types.TextContent(type="text", text=json.dumps({
@@ -877,7 +877,7 @@ def handle_detect_lateral_movement_paths(ctx, arguments: dict) -> list:
         )
 
         flows = pce.get_traffic_flows_async(query_name='lateral-movement', traffic_query=traffic_query)
-        df = to_dataframe(flows)
+        df = to_dataframe(pce, flows)
 
         if df.empty or 'src_app' not in df.columns or 'dst_app' not in df.columns:
             return [types.TextContent(type="text", text=json.dumps({

--- a/src/illumio_mcp/tools/rulesets.py
+++ b/src/illumio_mcp/tools/rulesets.py
@@ -2,15 +2,14 @@ import json
 import logging
 import mcp.types as types
 from illumio import RuleSet, LabelSet, Rule, AMS, ServicePort
-from ..pce import get_pce
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_get_rulesets(arguments: dict) -> list:
+def handle_get_rulesets(ctx, arguments: dict) -> list:
     logger.debug(f"GET RULESETS CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {}
         for param in ['name', 'description', 'labels']:
@@ -86,7 +85,7 @@ def handle_get_rulesets(arguments: dict) -> list:
         )]
 
 
-def handle_create_ruleset(arguments: dict) -> list:
+def handle_create_ruleset(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("CREATE RULESET CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -94,7 +93,7 @@ def handle_create_ruleset(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # populate the label maps
         label_href_map = {}
@@ -327,7 +326,7 @@ def handle_create_ruleset(arguments: dict) -> list:
         )]
 
 
-def handle_update_ruleset(arguments: dict) -> list:
+def handle_update_ruleset(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("UPDATE RULESET CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -335,7 +334,7 @@ def handle_update_ruleset(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find the ruleset
         ruleset = None
@@ -443,7 +442,7 @@ def handle_update_ruleset(arguments: dict) -> list:
         )]
 
 
-def handle_delete_ruleset(arguments: dict) -> list:
+def handle_delete_ruleset(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("DELETE RULESET CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -451,7 +450,7 @@ def handle_delete_ruleset(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find the ruleset
         ruleset = None
@@ -497,14 +496,14 @@ def handle_delete_ruleset(arguments: dict) -> list:
         )]
 
 
-def handle_provision_policy(arguments: dict) -> list:
+def handle_provision_policy(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("PROVISION POLICY CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         change_description = arguments.get("change_description", "Provisioned via MCP")
         hrefs = arguments.get("hrefs")

--- a/src/illumio_mcp/tools/services.py
+++ b/src/illumio_mcp/tools/services.py
@@ -1,12 +1,11 @@
 import json
 import logging
 import mcp.types as types
-from ..pce import get_pce
 
 logger = logging.getLogger('illumio_mcp')
 
 
-def handle_get_services(arguments: dict) -> list:
+def handle_get_services(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET SERVICES CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -14,7 +13,7 @@ def handle_get_services(arguments: dict) -> list:
 
     try:
         logger.debug("Initializing PCE connection...")
-        pce = get_pce()
+        pce = ctx.pce
 
         params = {}
         for param in ['name', 'description', 'port', 'proto', 'process_name', 'max_results']:
@@ -100,10 +99,10 @@ def handle_get_services(arguments: dict) -> list:
         )]
 
 
-def handle_create_service(arguments: dict) -> list:
+def handle_create_service(ctx, arguments: dict) -> list:
     logger.debug(f"CREATE SERVICE CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         payload = {
             "name": arguments["name"],
@@ -125,10 +124,10 @@ def handle_create_service(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_update_service(arguments: dict) -> list:
+def handle_update_service(ctx, arguments: dict) -> list:
     logger.debug(f"UPDATE SERVICE CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find service by href or name
         service_href = None
@@ -170,10 +169,10 @@ def handle_update_service(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}, indent=2))]
 
 
-def handle_delete_service(arguments: dict) -> list:
+def handle_delete_service(ctx, arguments: dict) -> list:
     logger.debug(f"DELETE SERVICE CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         service_href = None
         if arguments.get("href"):

--- a/src/illumio_mcp/tools/traffic.py
+++ b/src/illumio_mcp/tools/traffic.py
@@ -6,7 +6,7 @@ import mcp.types as types
 from illumio import TrafficQuery
 from illumio.explorer.trafficanalysis import TrafficQueryFilter
 from illumio.util.jsonutils import Reference
-from ..pce import get_pce, run_sync
+from ..pce import run_sync
 from .constants import MCP_BUG_MAX_RESULTS, MCP_MAX_RESPONSE_BYTES
 
 logger = logging.getLogger('illumio_mcp')
@@ -54,8 +54,7 @@ def _build_split_response(df, total_pce_flows, total_grouped_rows):
     return _serialize(best)
 
 
-def to_dataframe(flows):
-    pce = get_pce()
+def to_dataframe(pce, flows):
 
     label_href_map = {}
     value_href_map = {}
@@ -202,7 +201,7 @@ def summarize_traffic(df):
     return "\n".join(summary_list)
 
 
-def handle_get_traffic_flows(arguments: dict) -> list:
+def handle_get_traffic_flows(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET TRAFFIC FLOWS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -236,7 +235,7 @@ def handle_get_traffic_flows(arguments: dict) -> list:
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         logger.debug(f"Due to a condition in MCP, max results is set to {MCP_BUG_MAX_RESULTS}")
         arguments['max_results'] = MCP_BUG_MAX_RESULTS
@@ -264,7 +263,7 @@ def handle_get_traffic_flows(arguments: dict) -> list:
             headers={'Accept': 'application/json'}
         )
 
-        df = to_dataframe(all_traffic)
+        df = to_dataframe(pce, all_traffic)
 
         if df.empty:
             return [types.TextContent(
@@ -299,7 +298,7 @@ def handle_get_traffic_flows(arguments: dict) -> list:
         )]
 
 
-def handle_get_traffic_flows_summary(arguments: dict) -> list:
+def handle_get_traffic_flows_summary(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET TRAFFIC FLOWS SUMMARY CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
@@ -318,7 +317,7 @@ def handle_get_traffic_flows_summary(arguments: dict) -> list:
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         logger.debug(f"Due to a condition in MCP, max results is set to {MCP_BUG_MAX_RESULTS}")
         max_results = int(arguments.get('max_results', 10000))
@@ -350,7 +349,7 @@ def handle_get_traffic_flows_summary(arguments: dict) -> list:
             headers={'Accept': 'application/json'}
         )
 
-        df = to_dataframe(all_traffic)
+        df = to_dataframe(pce, all_traffic)
         summary = summarize_traffic(df)
 
         summary_lines = ""
@@ -377,14 +376,14 @@ def handle_get_traffic_flows_summary(arguments: dict) -> list:
         )]
 
 
-def handle_find_unmanaged_traffic(arguments: dict) -> list:
+def handle_find_unmanaged_traffic(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("FIND UNMANAGED TRAFFIC CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         lookback_days = arguments.get("lookback_days", 30)
         direction = arguments.get("direction", "both")
@@ -403,7 +402,7 @@ def handle_find_unmanaged_traffic(arguments: dict) -> list:
         )
 
         flows = pce.get_traffic_flows_async(query_name='unmanaged-traffic', traffic_query=traffic_query)
-        df = to_dataframe(flows)
+        df = to_dataframe(pce, flows)
 
         if df.empty:
             return [types.TextContent(type="text", text=json.dumps({

--- a/src/illumio_mcp/tools/workloads.py
+++ b/src/illumio_mcp/tools/workloads.py
@@ -3,7 +3,6 @@ import logging
 import pandas as pd
 import mcp.types as types
 from illumio import Label, Workload, Interface
-from ..pce import get_pce
 from .constants import MCP_MAX_RESPONSE_BYTES
 
 logger = logging.getLogger('illumio_mcp')
@@ -153,14 +152,14 @@ def _format_labels_only(workloads, label_map):
     return _truncate_split(df, {"total": len(rows)})
 
 
-def handle_get_workloads(arguments: dict) -> list:
+def handle_get_workloads(ctx, arguments: dict) -> list:
     logger.debug("=" * 80)
     logger.debug("GET WORKLOADS CALLED")
     logger.debug(f"Arguments received: {json.dumps(arguments, indent=2)}")
     logger.debug("=" * 80)
 
     try:
-        pce = get_pce()
+        pce = ctx.pce
         detail_level = arguments.get('detail_level', 'compact')
 
         params = {"include": "labels", "max_results": arguments.get('max_results', 10000)}
@@ -191,11 +190,11 @@ def handle_get_workloads(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}))]
 
 
-def handle_create_workload(arguments: dict) -> list:
+def handle_create_workload(ctx, arguments: dict) -> list:
     logger.debug(f"Creating workload with name: {arguments['name']} and ip_addresses: {arguments['ip_addresses']}")
     logger.debug(f"Labels: {arguments['labels']}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         interfaces = []
         prefix = "eth"
@@ -244,10 +243,10 @@ def handle_create_workload(arguments: dict) -> list:
         )]
 
 
-def handle_update_workload(arguments: dict) -> list:
+def handle_update_workload(ctx, arguments: dict) -> list:
     logger.debug(f"UPDATE WORKLOAD CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         # Find the workload by href or name
         workload_obj = None
@@ -307,10 +306,10 @@ def handle_update_workload(arguments: dict) -> list:
         return [types.TextContent(type="text", text=json.dumps({"error": error_msg}))]
 
 
-def handle_delete_workload(arguments: dict) -> list:
+def handle_delete_workload(ctx, arguments: dict) -> list:
     logger.debug(f"DELETE WORKLOAD CALLED with arguments: {json.dumps(arguments, indent=2)}")
     try:
-        pce = get_pce()
+        pce = ctx.pce
 
         workload_obj = None
         if arguments.get("href"):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,24 @@
+"""Tests for ToolContext dataclass."""
+import pytest
+from illumio_mcp.context import ToolContext
+
+
+def test_tool_context_holds_pce_and_mode():
+    sentinel_pce = object()
+    ctx = ToolContext(pce=sentinel_pce, is_stdio=True)
+    assert ctx.pce is sentinel_pce
+    assert ctx.is_stdio is True
+
+
+def test_tool_context_is_stdio_required():
+    """is_stdio is required; we never want an ambiguous context."""
+    with pytest.raises(TypeError):
+        ToolContext(pce=object())  # missing is_stdio
+
+
+def test_tool_context_can_be_extended_with_kwargs():
+    """Future fields (user_sub, role, etc.) can be added as kwargs without
+    breaking call sites that build a stdio context."""
+    ctx = ToolContext(pce=object(), is_stdio=True)
+    # If/when we add fields with defaults, existing callers must keep working.
+    assert ctx.is_stdio is True

--- a/tests/test_pce_builder.py
+++ b/tests/test_pce_builder.py
@@ -1,0 +1,68 @@
+"""Tests for the PCE builder (per-credentials construction).
+
+The builder must NOT cache. Each call returns a fresh client. This is what
+makes per-user PCE clients possible in Phase 3.
+"""
+from illumio_mcp.pce import (
+    PCECredentials, build_pce_for, get_pce_from_env, get_pce,
+)
+
+
+def test_build_pce_for_returns_fresh_instance_each_call():
+    creds = PCECredentials(
+        host="https://example.test",
+        port=8443,
+        org_id=1,
+        api_key="api_key_123",
+        api_secret="secret_abc",
+        tls_verify=False,
+    )
+    a = build_pce_for(creds)
+    b = build_pce_for(creds)
+    assert a is not b
+
+
+def test_build_pce_for_sets_credentials_and_tls_verify():
+    creds = PCECredentials(
+        host="https://example.test",
+        port=8443,
+        org_id=1,
+        api_key="api_key_123",
+        api_secret="secret_abc",
+        tls_verify=False,
+    )
+    pce = build_pce_for(creds)
+    assert pce._session.verify is False
+
+
+def test_get_pce_from_env_caches_singleton(monkeypatch):
+    """Stdio mode keeps a process-wide singleton — that's the existing
+    behavior we must preserve."""
+    monkeypatch.setenv("PCE_HOST", "https://example.test")
+    monkeypatch.setenv("PCE_PORT", "8443")
+    monkeypatch.setenv("PCE_ORG_ID", "1")
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("API_SECRET", "s")
+    # Reset the singleton in case a previous test populated it
+    import illumio_mcp.pce as pce_mod
+    pce_mod._stdio_singleton = None
+
+    a = get_pce_from_env()
+    b = get_pce_from_env()
+    assert a is b
+
+
+def test_get_pce_is_alias_for_env_singleton(monkeypatch):
+    """Existing call sites use get_pce(); it must keep returning the singleton
+    so handlers continue to work until Task 16 swaps the dispatch path."""
+    monkeypatch.setenv("PCE_HOST", "https://example.test")
+    monkeypatch.setenv("PCE_PORT", "8443")
+    monkeypatch.setenv("PCE_ORG_ID", "1")
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("API_SECRET", "s")
+    import illumio_mcp.pce as pce_mod
+    pce_mod._stdio_singleton = None
+
+    a = get_pce()
+    b = get_pce_from_env()
+    assert a is b

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,42 @@
+"""Tests for ToolSpec and role constants."""
+import pytest
+from illumio_mcp.registry import (
+    ToolSpec, Role, READER, OPERATOR, ADMIN, ALL_ROLES,
+)
+
+
+def _h(ctx, arguments):
+    return []
+
+
+def test_role_constants_are_distinct_strings():
+    assert {READER, OPERATOR, ADMIN} == {"reader", "operator", "admin"}
+
+
+def test_all_roles_contains_three():
+    assert ALL_ROLES == {READER, OPERATOR, ADMIN}
+
+
+def test_toolspec_requires_non_empty_roles():
+    """Default-deny: a tool with no roles is a configuration error."""
+    with pytest.raises(ValueError, match="at least one role"):
+        ToolSpec(handler=_h, roles=set())
+
+
+def test_toolspec_rejects_unknown_role():
+    with pytest.raises(ValueError, match="unknown role"):
+        ToolSpec(handler=_h, roles={"superuser"})  # type: ignore[arg-type]
+
+
+def test_toolspec_defaults():
+    spec = ToolSpec(handler=_h, roles={ADMIN})
+    assert spec.mutating is False
+    assert spec.requires_confirm is False
+    assert spec.unscopable is False
+
+
+def test_toolspec_requires_confirm_implies_mutating():
+    """requires_confirm only makes sense for mutating tools; we enforce it
+    so a typo can't silently expose a confirm-required-but-not-mutating tool."""
+    with pytest.raises(ValueError, match="mutating"):
+        ToolSpec(handler=_h, roles={ADMIN}, requires_confirm=True)

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -1,0 +1,59 @@
+"""Guard tests for the TOOL_REGISTRY.
+
+These run fast (no PCE) and exist to keep the registry self-consistent as new
+tools are added. If you're tempted to skip one, write a comment in this file
+explaining why instead.
+"""
+import inspect
+import re
+
+from illumio_mcp.tools import TOOL_REGISTRY
+from illumio_mcp.registry import ToolSpec, ALL_ROLES
+
+
+def test_every_tool_has_a_toolspec():
+    """If this fails, someone added a handler to TOOL_HANDLERS by mistake or
+    forgot to migrate to TOOL_REGISTRY."""
+    for name, spec in TOOL_REGISTRY.items():
+        assert isinstance(spec, ToolSpec), f"{name!r} is not a ToolSpec"
+
+
+def test_every_tool_has_explicit_roles():
+    for name, spec in TOOL_REGISTRY.items():
+        assert spec.roles, f"{name!r} has no roles assigned (default-deny violated)"
+        assert set(spec.roles).issubset(ALL_ROLES), \
+            f"{name!r} has unknown roles: {spec.roles}"
+
+
+def test_handlers_have_ctx_first_argument():
+    """Every handler must accept (ctx, arguments). Catches missed conversions."""
+    for name, spec in TOOL_REGISTRY.items():
+        sig = inspect.signature(spec.handler)
+        params = list(sig.parameters.keys())
+        assert len(params) >= 2, f"{name!r} handler has fewer than 2 params: {params}"
+        assert params[0] == "ctx", f"{name!r} handler's first param is {params[0]!r}, expected 'ctx'"
+
+
+def test_destructive_tool_names_are_marked_mutating():
+    """A tool whose name starts with create-/update-/delete-/provision-
+    must be `mutating=True`. Catches a contributor adding e.g. delete-foo
+    and forgetting the mutating flag."""
+    pattern = re.compile(r"^(create|update|delete|provision)-")
+    for name, spec in TOOL_REGISTRY.items():
+        if pattern.match(name):
+            assert spec.mutating, f"{name!r} looks destructive but mutating=False"
+
+
+def test_ringfence_batch_requires_confirm():
+    """ringfence-batch and provision-policy are explicit confirm-required tools
+    per spec §9. If the metadata gets edited by mistake, this catches it."""
+    for name in ("provision-policy", "ringfence-batch"):
+        spec = TOOL_REGISTRY[name]
+        assert spec.requires_confirm, f"{name!r} should require confirm token"
+
+
+def test_count_matches_expected():
+    """Sanity check: tool count is stable. Bump this when you intentionally
+    add or remove a tool."""
+    assert len(TOOL_REGISTRY) == 43, \
+        f"Tool count drifted to {len(TOOL_REGISTRY)}; update this test if intentional"


### PR DESCRIPTION
## Summary

Phase 1 of the HTTP transport + multi-user auth work. Pure refactor — no user-visible behavior change. Stdio entry point is unchanged.

- Every tool handler now takes `(ctx, arguments)` instead of `(arguments)`. The `ctx` is a `ToolContext` carrying the PCE client and a stdio flag — designed so Phase 2/3 can extend it with user identity, role, scopes, and request_id without touching call sites.
- `pce.py` split into `build_pce_for(creds)` (per-credentials builder, no caching) and `get_pce_from_env()` (process-wide stdio singleton built from env vars). `get_pce()` kept as a back-compat alias.
- `tools/__init__.py` is now `TOOL_REGISTRY: dict[str, ToolSpec]` carrying role / mutating / requires_confirm / unscopable metadata that Phase 3 authz will read. `TOOL_HANDLERS` retained as a derived back-compat dict.
- New CI guards (`tests/test_tool_metadata.py`): every tool has explicit roles; `create-/update-/delete-/provision-` named tools are `mutating=True`; `provision-policy` and `ringfence-batch` require confirm tokens; tool count == 43.
- Bug caught + fixed during regression: missed `to_dataframe(pce, ...)` call sites in `ringfence.py` and `policy.py` (the cross-file callers of the helper that was modified in the traffic.py task).

Spec: [`docs/superpowers/specs/2026-05-12-http-transport-and-auth-design.md`](../blob/feature/tool-context-refactor/docs/superpowers/specs/2026-05-12-http-transport-and-auth-design.md)
Plan: [`docs/superpowers/plans/2026-05-12-phase-1-tool-context-refactor.md`](../blob/feature/tool-context-refactor/docs/superpowers/plans/2026-05-12-phase-1-tool-context-refactor.md)

## What this PR does NOT do

- HTTP transport — Phase 2.
- OAuth Resource Server / JWT validation — Phase 3.
- Per-user PCE key storage (KeyStore + envelope encryption) — Phase 3.
- Authz enforcement — the `roles=` metadata is recorded but no middleware reads it yet — Phase 3.

## Test plan

- [x] `pytest tests/test_context.py tests/test_registry.py tests/test_pce_builder.py tests/test_tool_metadata.py -v` — 19 PASSED (fast, no PCE)
- [x] `pytest tests/test_mcp_tools.py -v` — same failure profile as `main`: 41 passed, 1 skipped, 2 pre-existing failures (`TestWorkloads::test_get_workloads` asserts an obsolete `"Workloads:"` prefix; `TestEnhancedReads::test_get_labels_with_key_value_filter` fails on PCE substring matching `role` → `servicerole`). Both verified failing on `main` independently.
- [x] Manual stdio JSON-RPC `initialize` handshake against `python -m illumio_mcp` returns valid response with `protocolVersion` and `serverInfo`
- [ ] (reviewer) Try with Claude Desktop pointed at the branch's `python -m illumio_mcp` to confirm end-to-end UX is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)