### PR TITLE
docs: full operator + developer documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# Illumio MCP Server — Documentation
+
+This directory contains the full operator, security, and developer documentation for the Illumio MCP Server after the Phase 1-3e rollout. For a top-level feature overview, see the [project README](../README.md).
+
+---
+
+## Deployment shapes
+
+The server supports four deployment shapes. Choose the one that matches your situation:
+
+| Shape | Command | Auth | Use when |
+|---|---|---|---|
+| **Stdio** | `illumio-mcp` or `python -m illumio_mcp` | None (trust the OS user) | Local power user, Claude Desktop, Cursor |
+| **HTTP dev-insecure** | `MCP_DEV_INSECURE=1 illumio-mcp-http` | None | Local integration testing, MCP Inspector smoke tests |
+| **HTTP per-user** | `illumio-mcp-http` | JWT + per-user PCE key | Production default; each human has their own PCE API key |
+| **HTTP shared** | `MCP_PCE_MODE=shared illumio-mcp-http` | JWT + shared service account | Fast onboarding; operators rely on the MCP audit log for attribution |
+
+---
+
+## Operations
+
+| Document | Description |
+|---|---|
+| [operations/quickstart.md](operations/quickstart.md) | Five-minute guide to get any deployment shape running |
+| [operations/configuration.md](operations/configuration.md) | Every environment variable in one table, organized by feature group |
+| [operations/stdio-mode.md](operations/stdio-mode.md) | Stdio deployment: Claude Desktop and Cursor config snippets |
+| [operations/http-mode.md](operations/http-mode.md) | HTTP modes: per-user, shared, architecture, safety gates, health endpoints |
+| [operations/oauth-providers/entra.md](operations/oauth-providers/entra.md) | Microsoft Entra ID (Azure AD) step-by-step recipe |
+| [operations/oauth-providers/okta.md](operations/oauth-providers/okta.md) | Okta Custom Authorization Server recipe |
+| [operations/oauth-providers/auth0.md](operations/oauth-providers/auth0.md) | Auth0 Custom API recipe |
+| [operations/oauth-providers/keycloak.md](operations/oauth-providers/keycloak.md) | Keycloak realm + client recipe |
+| [operations/audit-log.md](operations/audit-log.md) | Audit log schema, sample queries, retention, and SIEM shipping |
+| [operations/troubleshooting.md](operations/troubleshooting.md) | Common errors and fixes |
+
+---
+
+## Security
+
+| Document | Description |
+|---|---|
+| [security/architecture.md](security/architecture.md) | Five-layer defense diagram, crypto choices, file permissions |
+| [security/threat-model.md](security/threat-model.md) | What the design protects against, what it does not, honest trade-offs |
+| [security/secret-management.md](security/secret-management.md) | Generation, rotation, and storage guidance for every secret |
+
+---
+
+## Development
+
+| Document | Description |
+|---|---|
+| [development/code-layout.md](development/code-layout.md) | Package structure and the full dispatch flow |
+| [development/adding-a-tool.md](development/adding-a-tool.md) | Step-by-step recipe for adding a new MCP tool |
+| [development/testing.md](development/testing.md) | How to run unit, HTTP, and integration tests locally |

--- a/docs/development/adding-a-tool.md
+++ b/docs/development/adding-a-tool.md
@@ -1,0 +1,159 @@
+# Adding a New Tool
+
+Five steps to add a new MCP tool. Each step is mechanical. The worked example below adds a hypothetical `get-services-by-port` tool.
+
+---
+
+## Step 1: Write the handler
+
+Add a new handler function in the appropriate `tools/*.py` file. Pick the file that most closely matches the domain (`services.py` for service-related tools, `workloads.py` for workload tools, etc.).
+
+**Signature:** `def handle_<tool_name>(ctx, arguments: dict) -> list:`
+
+The body reads `ctx.pce` to access the PCE client. Never import `get_pce()` or anything from `transport/` or `auth/` inside a tool handler.
+
+```python
+# src/illumio_mcp/tools/services.py
+
+def handle_get_services_by_port(ctx, arguments: dict) -> list:
+    """Return services that include the specified port."""
+    port = int(arguments.get("port", 0))
+    if not port:
+        return [types.TextContent(type="text", text=json.dumps({"error": "port is required"}))]
+    pce = ctx.pce
+    services = pce.services.get(params={"max_results": 500})
+    matching = [
+        s for s in services
+        if hasattr(s, "service_ports") and any(
+            getattr(sp, "port", None) == port for sp in (s.service_ports or [])
+        )
+    ]
+    return [types.TextContent(type="text", text=json.dumps(
+        [{"href": s.href, "name": s.name} for s in matching], indent=2
+    ))]
+```
+
+---
+
+## Step 2: Add the MCP Tool definition in `server.py`
+
+Add a `types.Tool` entry in `handle_list_tools()` in `src/illumio_mcp/server.py`. This is what MCP clients see in their tool list.
+
+```python
+types.Tool(
+    name="get-services-by-port",
+    description="Find service definitions that include a specific port number.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "port": {
+                "type": "integer",
+                "description": "TCP/UDP port number to search for.",
+            },
+        },
+        "required": ["port"],
+    },
+),
+```
+
+---
+
+## Step 3: Add a `ToolSpec` entry in `tools/__init__.py`
+
+Import the handler at the top of `src/illumio_mcp/tools/__init__.py` and add a `ToolSpec` entry in `TOOL_REGISTRY`.
+
+**Import:**
+
+```python
+from .services import (
+    handle_get_services,
+    handle_create_service,
+    handle_update_service,
+    handle_delete_service,
+    handle_get_services_by_port,   # add this line
+)
+```
+
+**Registry entry:**
+
+```python
+TOOL_REGISTRY: dict[str, ToolSpec] = {
+    ...
+    # Services
+    "get-services":           ToolSpec(handle_get_services,          roles=ALL_ROLES),
+    "create-service":         ToolSpec(handle_create_service,        roles=_OP_ADMIN, mutating=True),
+    "update-service":         ToolSpec(handle_update_service,        roles=_OP_ADMIN, mutating=True),
+    "delete-service":         ToolSpec(handle_delete_service,        roles=_OP_ADMIN, mutating=True),
+    "get-services-by-port":   ToolSpec(handle_get_services_by_port,  roles=ALL_ROLES),  # add this
+    ...
+}
+```
+
+**ToolSpec field cheatsheet:**
+
+| Field | Type | Meaning |
+|---|---|---|
+| `roles` | `frozenset` | Who can call this tool. Use `ALL_ROLES`, `_OP_ADMIN`, or `_ADMIN_ONLY`. Must be non-empty. |
+| `mutating` | `bool` | `True` if the tool creates, updates, or deletes PCE state. Required for tools whose name starts with `create-`, `update-`, `delete-`, or `provision-`. |
+| `requires_confirm` | `bool` | `True` for highly destructive tools (provision, ringfence-batch). Implies `mutating=True`. |
+| `unscopable` | `bool` | `True` if the tool returns PCE-wide data that cannot be safely filtered per user scope. |
+| `requires_pce` | `bool` | `False` only for credential-management tools that work before a user has a PCE key. Default `True`. |
+
+---
+
+## Step 4: Update the tool count in `test_tool_metadata.py`
+
+The guard test `test_count_matches_expected` in `tests/test_tool_metadata.py` asserts the exact tool count. Bump it when you add a tool:
+
+```python
+def test_count_matches_expected():
+    assert len(TOOL_REGISTRY) == 47, \  # was 46, bumped for get-services-by-port
+        f"Tool count drifted to {len(TOOL_REGISTRY)}; update this test if intentional"
+```
+
+Verify:
+
+```bash
+.venv/bin/python3 -m pytest tests/test_tool_metadata.py -v
+```
+
+Expected: all 6 guard tests pass.
+
+---
+
+## Step 5: Add a test
+
+Add an integration or unit test for the new tool. For tools that require a real PCE, add to the appropriate `tests/test_mcp_tools.py` test class. For tools you can test with a stub PCE, add to a fast unit test.
+
+```python
+# tests/test_mcp_tools.py (integration, requires PCE)
+class TestServices:
+    def test_get_services_by_port(self, client):
+        result = client.call_tool("get-services-by-port", {"port": 443})
+        data = json.loads(result.content[0].text)
+        assert isinstance(data, list)
+```
+
+---
+
+## What the dispatcher will enforce automatically
+
+Once your `ToolSpec` entry is in `TOOL_REGISTRY`, the dispatcher handles the rest:
+
+- Users without a role in `spec.roles` get `{"error": "forbidden"}`.
+- Users in per-user mode without PCE credentials (if `spec.requires_pce=True`) get `{"error": "no_pce_credentials"}`.
+- HTTP callers without a confirm token (if `spec.requires_confirm=True`) get `{"error": "confirm_required"}`.
+- Every decision is recorded in the audit log.
+
+You do not need to add any authz code to the handler itself.
+
+---
+
+## CI guards that catch common mistakes
+
+The `tests/test_tool_metadata.py` guards will fail at CI time if:
+
+- The tool is in `TOOL_REGISTRY` but has an empty `roles=` set (caught by `ToolSpec.__post_init__`).
+- The handler's first parameter is not named `ctx` (caught by `test_handlers_have_ctx_first_argument`).
+- A tool whose name starts with `create-`/`update-`/`delete-`/`provision-` does not have `mutating=True` (caught by `test_destructive_tool_names_are_marked_mutating`).
+- The tool count does not match the assertion (caught by `test_count_matches_expected`).

--- a/docs/development/code-layout.md
+++ b/docs/development/code-layout.md
@@ -1,0 +1,141 @@
+# Code Layout
+
+Overview of the package structure for contributors. Every module has a single well-defined responsibility.
+
+---
+
+## Package tree
+
+```
+src/illumio_mcp/
+  __init__.py          # Exports main() (stdio) and serve_http_cli() (HTTP)
+  __main__.py          # python -m illumio_mcp arg parser; default = stdio
+  server.py            # mcp.Server instance; ToolContext builders; dispatcher
+  context.py           # ToolContext dataclass
+  registry.py          # ToolSpec dataclass + Role constants
+  pce.py               # PCECredentials; build_pce_for(); get_pce_from_env()
+
+  auth/
+    __init__.py        # Package docstring; no re-exports
+    config.py          # OAuthConfig; load_oauth_config_from_env(); is_dev_insecure()
+    jwt_validator.py   # JWTValidator; AuthenticatedUser; InvalidTokenError
+    middleware.py      # JWTAuthMiddleware (Starlette BaseHTTPMiddleware)
+    prm.py             # build_prm_document() — RFC 9728 PRM response
+    keystore.py        # KeyStore protocol; SQLiteKeyStore (WAL, envelope-encrypted)
+    keystore_init.py   # build_keystore_from_env() — reads MCP_KEYSTORE_PATH + MCP_KEK
+    crypto.py          # EnvelopeCipher (AES-256-GCM two-tier); load_kek_from_env()
+    roles.py           # RoleConfig; load_role_config_from_env(); map_user_role()
+    audit.py           # AuditEntry; AuditLog protocol; SQLiteAuditLog; NullAuditLog
+    audit_init.py      # build_audit_log_from_env() — reads MCP_AUDIT_LOG_PATH
+    confirm.py         # ConfirmTokenManager; ConfirmTokenClaims; canonical_params_hash()
+    confirm_replay.py  # JtiStore protocol; SQLiteJtiStore; NullJtiStore
+    confirm_init.py    # build_confirm_manager_from_env() — reads MCP_CONFIRM_* vars
+    pce_mode.py        # PCEMode literal; load_pce_mode_from_env(); is_shared_mode()
+
+  transport/
+    __init__.py        # Package docstring
+    http.py            # Starlette app factory; serve_http(); main() CLI entry
+    setup_page.py      # /setup GET+POST routes (HTML form for per-user onboarding)
+    confirm_endpoint.py # /confirm POST route (mint confirm token)
+    request_id.py      # RequestIdMiddleware — per-request UUID → X-Request-Id
+
+  tools/
+    __init__.py        # TOOL_REGISTRY: dict[str, ToolSpec] (the canonical list)
+    workloads.py       # handle_get_workloads, handle_create_workload, ...
+    labels.py          # handle_get_labels, handle_create_label, ...
+    services.py        # handle_get_services, handle_create_service, ...
+    iplists.py         # handle_get_iplists, handle_create_iplist, ...
+    rulesets.py        # handle_get_rulesets, handle_create_ruleset, ..., handle_provision_policy
+    deny_rules.py      # handle_create_deny_rule, handle_update_deny_rule, ...
+    traffic.py         # handle_get_traffic_flows, ..., to_dataframe(pce, flows)
+    policy.py          # handle_compliance_check, handle_enforcement_readiness, ...
+    ringfence.py       # handle_create_ringfence, handle_ringfence_batch, ...
+    containers.py      # handle_get_container_clusters, ...
+    infra.py           # handle_check_pce_connection, handle_get_events, ...
+    credentials.py     # handle_register_pce_credentials, handle_delete_pce_credentials, ...
+```
+
+---
+
+## The dispatch flow
+
+Understanding this flow is necessary for any change that touches authentication, authorization, or tool execution.
+
+### HTTP request path
+
+```
+1. HTTP client sends: POST /mcp  Authorization: Bearer <jwt>
+
+2. RequestIdMiddleware (transport/request_id.py)
+   - Generates UUID or honors X-Request-Id header
+   - Sets request.state.request_id
+   - Adds X-Request-Id to response
+
+3. JWTAuthMiddleware (auth/middleware.py)
+   - Extracts Bearer token from Authorization header
+   - Calls JWTValidator.validate(token) (auth/jwt_validator.py)
+   - On failure: returns 401 with WWW-Authenticate header
+   - On success: sets request.state.user = AuthenticatedUser(sub, iss, scopes, groups)
+
+4. ASGI context wrapper (transport/http.py _wrap_with_per_request_context)
+   - Reads request.state.user and request.state.request_id
+   - Calls map_user_role(user.groups, role_config) (auth/roles.py)
+   - Calls build_http_context_for(sub, iss, keystore, role, audit_log, request_id,
+       confirm_manager=..., jti_store=..., pce_mode=...) (server.py)
+     - In per_user mode: keystore.get(sub=sub, iss=iss) → PCECredentials
+       → build_pce_for(creds) (pce.py)
+     - In shared mode: get_pce_from_env() (pce.py)
+     - Sets ctx.pce = None if no creds found (per_user, no row yet)
+   - Calls set_http_context(ctx) — stores ctx in a ContextVar
+   - Invokes StreamableHTTPSessionManager
+
+5. mcp.Server (server.py) routes the JSON-RPC method to handle_call_tool()
+
+6. dispatcher (server.py handle_call_tool)
+   - ctx = get_active_context() — reads the ContextVar
+   - spec = TOOL_REGISTRY.get(tool_name)
+   - Gate 1: spec.roles — does ctx.user_role ∈ spec.roles?
+     No → audit denied, return {"error": "forbidden"}
+   - Gate 2: spec.requires_pce — is ctx.pce non-None?
+     No → audit denied, return {"error": "no_pce_credentials", "setup_url": ...}
+   - Gate 3: spec.requires_confirm (HTTP only) — is params._meta.confirm_token valid?
+     No → audit denied, return {"error": "confirm_required", "params_hash": ...}
+     Invalid/replayed → audit denied, return {"error": "..."}
+   - All gates passed → audit allowed
+   - result = await asyncio.to_thread(spec.handler, ctx, arguments)
+
+7. Handler (e.g. tools/workloads.py handle_get_workloads)
+   - Reads ctx.pce — the per-request PolicyComputeEngine client
+   - Makes PCE API calls via python-illumio
+   - Returns list[types.TextContent]
+```
+
+### Stdio path
+
+The stdio path is simpler:
+
+```
+python -m illumio_mcp
+  → __main__.py → main() → asyncio.run(server.run_stdio())
+  → server.py run_stdio() starts MCP stdio loop
+  → handle_call_tool: ctx = _get_stdio_context()
+    (ToolContext with pce=get_pce_from_env(), is_stdio=True, role="admin",
+     user_sub=None, user_iss=None, audit_log=NullAuditLog())
+  → same dispatcher, but all gate checks pass for admin + is_stdio=True
+```
+
+---
+
+## Key design decisions
+
+**ContextVar for per-request ToolContext in HTTP mode**
+
+The mcp SDK's `StreamableHTTPSessionManager` does not thread user context through to tool handlers. We use a `contextvars.ContextVar` (`_http_context_var` in `server.py`) to carry the per-request `ToolContext`. The ASGI wrapper sets it before invoking the session manager and resets it in a `finally` block. This is safe for asyncio (each Task has its own context copy).
+
+**Default-deny in `TOOL_REGISTRY`**
+
+`ToolSpec.__post_init__` raises `ValueError` if `roles=` is empty or contains an unknown role. This means the server fails to import if a tool is added without explicit roles. CI catches this with `test_tool_metadata.py`.
+
+**Handlers are transport-agnostic**
+
+Handlers in `tools/*.py` only receive `(ctx, arguments)`. They never import from `transport/` or `auth/`. All authz enforcement happens before the handler is called.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,188 @@
+# Testing
+
+Three tiers of tests. Most work without a real PCE.
+
+---
+
+## Tier 1: Fast unit tests (no PCE required)
+
+These test authentication, authorization, crypto, and registry correctness. They run in under 10 seconds with no external dependencies.
+
+```bash
+.venv/bin/python3 -m pytest \
+  tests/test_auth_config.py \
+  tests/test_auth_jwt_validator.py \
+  tests/test_auth_prm.py \
+  tests/test_auth_crypto.py \
+  tests/test_auth_keystore.py \
+  tests/test_auth_roles.py \
+  tests/test_auth_audit.py \
+  tests/test_auth_confirm.py \
+  tests/test_auth_confirm_replay.py \
+  tests/test_auth_pce_mode.py \
+  tests/test_context.py \
+  tests/test_registry.py \
+  tests/test_pce_builder.py \
+  tests/test_tool_metadata.py \
+  tests/test_credentials_tools.py \
+  -v
+```
+
+### What each test file covers
+
+| File | Coverage |
+|---|---|
+| `test_auth_config.py` | `OAuthConfig` env loading, `is_dev_insecure()`, `MissingOAuthConfigError` |
+| `test_auth_jwt_validator.py` | Happy path + all 6 failure modes (bad sig, wrong iss, wrong aud, expired, missing scope, garbage) |
+| `test_auth_prm.py` | RFC 9728 PRM document shape |
+| `test_auth_crypto.py` | `EnvelopeCipher` round-trip, AAD binding, tamper detection |
+| `test_auth_keystore.py` | `SQLiteKeyStore` CRUD, upsert, delete, missing-row handling |
+| `test_auth_roles.py` | Group→role mapping, highest-role-wins, default_role fallback |
+| `test_auth_audit.py` | `SQLiteAuditLog` writes, `NullAuditLog` no-ops |
+| `test_auth_confirm.py` | `ConfirmTokenManager` mint/verify, all failure modes |
+| `test_auth_confirm_replay.py` | `SQLiteJtiStore` mark-used, replay rejection |
+| `test_auth_pce_mode.py` | `load_pce_mode_from_env()`, defaults, invalid values |
+| `test_context.py` | `ToolContext` dataclass fields, defaults |
+| `test_registry.py` | `ToolSpec` validation, role constants |
+| `test_pce_builder.py` | `build_pce_for()` returns fresh instances, `get_pce_from_env()` caches |
+| `test_tool_metadata.py` | Guard tests: every tool has roles, `ctx`-first arg, mutating flag, count |
+| `test_credentials_tools.py` | `register-pce-credentials`, `delete-pce-credentials`, `check-pce-credentials-status` with a fake keystore |
+
+---
+
+## Tier 2: HTTP transport tests (in-process JWT signer, no real PCE)
+
+These spin up the full Starlette app in a background thread on a free local port, issue real HTTP requests, and exercise the auth middleware and session manager end-to-end. They use an in-process RSA key to sign test JWTs — no real IdP is needed.
+
+```bash
+.venv/bin/python3 -m pytest \
+  tests/test_http_transport.py \
+  tests/test_http_auth.py \
+  tests/test_http_authz.py \
+  tests/test_http_per_user.py \
+  tests/test_http_confirm.py \
+  tests/test_http_shared_mode.py \
+  -v
+```
+
+### Key patterns used in these tests
+
+**In-process JWT signing**
+
+```python
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import jwt as pyjwt
+
+rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+private_key_pem = rsa_key.private_bytes(...)
+public_key_pem = rsa_key.public_key().public_bytes(...)
+
+# Build a validator that uses the in-process key directly
+from illumio_mcp.auth.jwt_validator import JWTValidator
+from illumio_mcp.auth.config import OAuthConfig
+
+validator = JWTValidator(cfg, key_resolver=lambda kid: public_key_pem)
+
+# Mint a test token
+token = pyjwt.encode(
+    {"iss": cfg.issuer, "aud": cfg.audience, "sub": "test-user",
+     "exp": int(time.time()) + 600, "iat": int(time.time()),
+     "scope": "illumio-mcp.use", "groups": ["sg-test-admin"]},
+    private_key_pem, algorithm="RS256", headers={"kid": "test-kid"}
+)
+```
+
+**Stubbing `build_pce_for` and `get_pce_from_env`**
+
+Tests that need to bypass a real PCE monkeypatch the builder:
+
+```python
+import illumio_mcp.pce as pce_mod
+
+class FakePCE:
+    """Minimal PCE stub that returns empty lists for all queries."""
+    class _services:
+        @staticmethod
+        def get(**kwargs): return []
+    # ... add stubs as needed
+
+monkeypatch.setattr(pce_mod, "build_pce_for", lambda creds: FakePCE())
+monkeypatch.setattr(pce_mod, "get_pce_from_env", lambda: FakePCE())
+```
+
+**SQLite test databases with `tmp_path_factory`**
+
+```python
+@pytest.fixture(scope="module")
+def keystore(tmp_path_factory):
+    from illumio_mcp.auth.crypto import EnvelopeCipher, generate_kek
+    from illumio_mcp.auth.keystore import SQLiteKeyStore
+    db_path = str(tmp_path_factory.mktemp("keystore") / "keys.db")
+    return SQLiteKeyStore(db_path=db_path, cipher=EnvelopeCipher(generate_kek()))
+```
+
+**Streamable HTTP server fixture (free port + uvicorn thread)**
+
+```python
+@pytest.fixture(scope="module")
+def http_server_url(... other fixtures ...):
+    import uvicorn
+    from illumio_mcp.transport.http import _build_app
+    port = _free_port()
+    config = uvicorn.Config(_build_app(...), host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    # Wait for /healthz to respond
+    ...
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    thread.join(timeout=5)
+```
+
+---
+
+## Tier 3: Full integration tests against a real PCE
+
+These tests exercise the full tool handler logic against a real PCE instance. They require a `.env` file with valid PCE credentials.
+
+```bash
+# Create .env
+cat > .env <<EOF
+PCE_HOST=https://your-pce.example.com
+PCE_PORT=8443
+PCE_ORG_ID=1
+API_KEY=your-api-key
+API_SECRET=your-api-secret
+EOF
+
+# Run integration tests
+.venv/bin/python3 -m pytest tests/test_mcp_tools.py -v
+```
+
+These tests create and clean up real PCE objects (workloads, labels, rulesets). Run against a lab PCE, not production.
+
+To run the PCE-free tiers from CI while skipping the PCE tests:
+
+```bash
+.venv/bin/python3 -m pytest tests/ -q --ignore=tests/test_mcp_tools.py
+```
+
+---
+
+## Running all tiers at once
+
+```bash
+# With PCE configured in .env
+.venv/bin/python3 -m pytest tests/ -v
+
+# Without PCE (skips test_mcp_tools.py)
+.venv/bin/python3 -m pytest tests/ -q --ignore=tests/test_mcp_tools.py
+```
+
+Expected CI output (no PCE):
+
+```
+... passed, 0 failed
+```

--- a/docs/operations/audit-log.md
+++ b/docs/operations/audit-log.md
@@ -1,0 +1,148 @@
+# Audit Log
+
+The audit log is the authoritative record of "who called what tool and whether it was allowed." It is written by the dispatcher for every tool-call decision in HTTP auth mode.
+
+---
+
+## Schema
+
+The audit log lives in a SQLite database (default path alongside the keystore). Every record corresponds to one dispatcher decision.
+
+```sql
+CREATE TABLE audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts           TEXT NOT NULL,       -- ISO-8601 UTC timestamp
+    sub          TEXT,                -- IdP subject (user identity, NULL in stdio)
+    iss          TEXT,                -- IdP issuer URL (NULL in stdio)
+    tool         TEXT NOT NULL,       -- MCP tool name, e.g. "provision-policy"
+    decision     TEXT NOT NULL,       -- "allowed" | "denied" | "error"
+    reason       TEXT,                -- short machine-readable reason code (see below)
+    role         TEXT,                -- "reader" | "operator" | "admin" | NULL
+    request_id   TEXT                 -- UUID from X-Request-Id header
+);
+
+-- Indexes for common query patterns
+CREATE INDEX idx_audit_log_sub_ts    ON audit_log(sub, ts DESC);
+CREATE INDEX idx_audit_log_decision  ON audit_log(decision, ts DESC);
+```
+
+### Column meanings
+
+| Column | Notes |
+|---|---|
+| `ts` | UTC timestamp in ISO-8601 format. Monotonically increasing within a process. |
+| `sub` | The IdP `sub` claim — stable per user, not a display name. Map to display names via your IdP's directory. |
+| `iss` | The IdP issuer URL. Present for multi-IdP deployments (reserved for future use). |
+| `tool` | The MCP tool name as registered in `TOOL_REGISTRY`. |
+| `decision` | `allowed` — call was dispatched to the handler. `denied` — authz check failed. `error` — handler raised an exception. |
+| `reason` | Machine-readable code for denials. Values include: `forbidden_no_role`, `forbidden`, `no_pce_credentials`, `confirm_required`, `confirm_token_replay`, `invalid_confirm_token`. |
+| `role` | The role the user was granted at the time of the call. `NULL` if no role was assigned (for `forbidden_no_role` decisions). |
+| `request_id` | Matches the `X-Request-Id` response header on the corresponding HTTP request. Use this to correlate audit entries with HTTP server logs. |
+
+---
+
+## File location
+
+The audit database path is controlled by `MCP_AUDIT_LOG_PATH`. If not set, it defaults to `<keystore_directory>/audit.db`, where the keystore directory is derived from `MCP_KEYSTORE_PATH` (default `./data`). So by default the audit database is at `./data/audit.db`.
+
+The file is created at server startup with `chmod 600` permissions.
+
+In stdio mode, no audit log is written — a `NullAuditLog` is used.
+
+---
+
+## Sample queries
+
+```sql
+-- Recent denied calls per user (last 24h)
+SELECT ts, sub, tool, reason
+FROM audit_log
+WHERE decision = 'denied'
+  AND ts > datetime('now', '-1 day')
+ORDER BY ts DESC
+LIMIT 50;
+
+-- Tool-call volume by user (last 7 days)
+SELECT sub, COUNT(*) AS calls
+FROM audit_log
+WHERE ts > datetime('now', '-7 days')
+GROUP BY sub
+ORDER BY calls DESC;
+
+-- Who provisioned policy and when
+SELECT ts, sub, role, request_id
+FROM audit_log
+WHERE tool = 'provision-policy'
+  AND decision = 'allowed'
+ORDER BY ts DESC;
+
+-- Calls by a specific user
+SELECT ts, tool, decision, reason
+FROM audit_log
+WHERE sub = 'user-object-id-from-idp'
+ORDER BY ts DESC
+LIMIT 100;
+
+-- Error rate by tool
+SELECT tool, COUNT(*) AS errors
+FROM audit_log
+WHERE decision = 'error'
+GROUP BY tool
+ORDER BY errors DESC;
+```
+
+---
+
+## What is NOT logged
+
+The audit log deliberately excludes:
+
+- **Tool arguments** — PCE resource HREFs, IP addresses, label values, and any other tool parameters are not recorded. This prevents credential or PII leakage in the audit trail.
+- **Confirm token payloads** — the `params_hash` (SHA-256 of canonical parameters) is recorded by the confirm endpoint, but not the parameters themselves.
+- **PCE API responses** — the audit log records MCP-level decisions, not PCE-level results.
+- **JWT contents** — only the `sub` and `iss` claims (which identify the user and IdP) are extracted.
+
+---
+
+## Correlation with X-Request-Id
+
+Every HTTP request gets a UUID assigned by `RequestIdMiddleware` (or passed through if the client sends an `X-Request-Id` header). The audit log records this UUID in the `request_id` column.
+
+To trace a specific call end-to-end:
+
+1. Find the `request_id` in the audit log (e.g., from a user complaint).
+2. Search your HTTP server logs (uvicorn) for that UUID to find the exact HTTP timing and client IP.
+3. If PCE returned an error, the error text is in the tool's JSON response which is logged by the handler.
+
+---
+
+## Retention strategy
+
+The audit database is a local SQLite file. For compliance environments, ship it to a SIEM.
+
+**Option A: Cron-based purge (simplest)**
+
+```bash
+# Purge entries older than 90 days (run from cron daily)
+sqlite3 /var/lib/illumio-mcp/audit.db \
+  "DELETE FROM audit_log WHERE ts < datetime('now', '-90 days');"
+sqlite3 /var/lib/illumio-mcp/audit.db "VACUUM;"
+```
+
+**Option B: Fluent Bit tail to SIEM**
+
+If you run Fluent Bit, you can tail the SQLite file by periodically dumping new rows to a JSON file that Fluent Bit tails:
+
+```bash
+# Dump new rows since last checkpoint (adjust offset tracking as needed)
+sqlite3 /var/lib/illumio-mcp/audit.db \
+  "SELECT json_object('ts',ts,'sub',sub,'tool',tool,'decision',decision,'reason',reason,'role',role,'request_id',request_id) \
+   FROM audit_log WHERE id > $LAST_ID ORDER BY id;" \
+  >> /var/log/illumio-mcp-audit.jsonl
+```
+
+Then configure Fluent Bit to tail `/var/log/illumio-mcp-audit.jsonl` and forward to your SIEM (Splunk, Elastic, etc.).
+
+**Option C: Separate audit path (future)**
+
+A future release may add a structured JSON log stream that is easier to tail without SQLite tooling. Until then, the SQLite dump approach is the recommended path.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,0 +1,109 @@
+# Configuration Reference
+
+Every environment variable the server understands. In stdio mode only the first group applies. All other groups are for HTTP deployments.
+
+---
+
+## Stdio + shared PCE credentials
+
+These are the PCE connection settings used by stdio mode and by HTTP shared mode (`MCP_PCE_MODE=shared`).
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `PCE_HOST` | Always (stdio or shared HTTP) | — | URL | `https://pce.example.com` |
+| `PCE_PORT` | Always | — | Integer | `8443` |
+| `PCE_ORG_ID` | Always | — | Integer | `1` |
+| `API_KEY` | Always | — | String | `api_key_abc123` |
+| `API_SECRET` | Always | — | String | `secret_xyz...` |
+| `PCE_TLS_VERIFY` | Optional | `true` | `true` or `false` | `false` (disable for self-signed cert) |
+
+---
+
+## HTTP transport
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_HTTP_HOST` | Optional | `127.0.0.1` | IP or hostname | `0.0.0.0` |
+| `MCP_HTTP_PORT` | Optional | `8080` | Integer | `443` |
+| `MCP_DEV_INSECURE` | Never in production | unset | `1` | `1` |
+
+`MCP_DEV_INSECURE=1` disables all auth, skips OAuth config validation, and allows binding non-loopback addresses. The server logs a prominent warning. Never set this in production.
+
+---
+
+## OAuth Resource Server
+
+Required for all authenticated HTTP deployments (i.e., any deployment where `MCP_DEV_INSECURE` is not set).
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_OAUTH_ISSUER` | HTTP auth mode | — | URL | `https://login.microsoftonline.com/<tid>/v2.0` |
+| `MCP_OAUTH_JWKS_URL` | HTTP auth mode | — | URL | `https://login.microsoftonline.com/<tid>/discovery/v2.0/keys` |
+| `MCP_OAUTH_AUDIENCE` | HTTP auth mode | — | String | `https://mcp.illumio.example` |
+| `MCP_OAUTH_REQUIRED_SCOPE` | Optional | `illumio-mcp.use` | String | `illumio-mcp.use` |
+| `MCP_PUBLIC_URL` | HTTP auth mode | — | URL | `https://mcp.illumio.example` |
+
+`MCP_PUBLIC_URL` is the public-facing URL of this server, used in the RFC 9728 Protected Resource Metadata document (`/.well-known/oauth-protected-resource`). It must match the `resource_url` field MCP clients expect.
+
+---
+
+## PCE mode and keystore
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_PCE_MODE` | Optional | `per_user` | `per_user` or `shared` | `shared` |
+| `MCP_KEK` | `MCP_PCE_MODE=per_user` and auth mode | — | Base64 of 32 random bytes | (generate — see below) |
+| `MCP_KEYSTORE_PATH` | Optional | `./data/keys.db` | File path | `/var/lib/illumio-mcp/keys.db` |
+
+The `MCP_KEK` (Key-Encryption-Key) encrypts the per-user PCE secrets at rest. It is never stored in the SQLite database. Loss of `MCP_KEK` means all per-user credentials are permanently unrecoverable (intentional, fail-closed). In production, source it from KMS or Vault rather than a shell export.
+
+---
+
+## Role mapping
+
+Configure which IdP groups grant which MCP roles. Users are granted the highest role that any of their groups qualifies for.
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_ROLE_GROUPS_ADMIN` | Recommended | — | Comma-separated group names | `sg-illumio-mcp-admin` |
+| `MCP_ROLE_GROUPS_OPERATOR` | Recommended | — | Comma-separated group names | `sg-illumio-mcp-operator,sg-illumio-mcp-admin` |
+| `MCP_ROLE_GROUPS_READER` | Recommended | — | Comma-separated group names | `sg-illumio-mcp-readonly,sg-illumio-mcp-operator,sg-illumio-mcp-admin` |
+| `MCP_ROLE_DEFAULT` | Optional | unset (refuse) | `reader`, `operator`, or `admin` | `reader` |
+
+If `MCP_ROLE_DEFAULT` is unset and a user's JWT groups match none of the configured lists, the user receives a `forbidden_no_role` error and the call is denied.
+
+---
+
+## Audit log
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_AUDIT_LOG_PATH` | Optional | Derived from `MCP_KEYSTORE_PATH` | File path | `/var/lib/illumio-mcp/audit.db` |
+
+Default path is `<keystore_directory>/audit.db`. If `MCP_KEYSTORE_PATH` is also unset, defaults to `./data/audit.db`.
+
+---
+
+## Confirm tokens
+
+Required for HTTP auth mode (the server refuses to start without `MCP_CONFIRM_HMAC_KEY` when auth is enabled).
+
+| Var | Required when | Default | Format | Example |
+|---|---|---|---|---|
+| `MCP_CONFIRM_HMAC_KEY` | HTTP auth mode | — | Base64 of 32 random bytes | (generate — see below) |
+| `MCP_CONFIRM_TTL_SECONDS` | Optional | `120` | Integer | `300` |
+| `MCP_CONFIRM_JTI_PATH` | Optional | Derived from keystore dir | File path | `/var/lib/illumio-mcp/jti.db` |
+| `MCP_CONFIRM_FRESH_AUTH_SECONDS` | Optional | unset | Integer | `300` |
+
+`MCP_CONFIRM_FRESH_AUTH_SECONDS` requires the JWT's `auth_time` claim to be within this many seconds of the `/confirm` request. When set, the user must have re-authenticated recently before they can mint a confirm token — the strongest prompt-injection defense. Requires the IdP to issue `auth_time` (Entra and Okta do for OIDC flows).
+
+---
+
+## Generate all the secrets at once
+
+```bash
+echo "MCP_KEK=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')"
+echo "MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')"
+```
+
+Store the output in your secrets manager or KMS. Never commit these values to version control.

--- a/docs/operations/http-mode.md
+++ b/docs/operations/http-mode.md
@@ -1,0 +1,162 @@
+# HTTP Mode
+
+The HTTP transport exposes the MCP server over Streamable HTTP (MCP spec rev 2025-03-26), allowing any compliant MCP client to connect by URL rather than requiring a local subprocess install.
+
+---
+
+## Architectural overview
+
+Every authenticated request passes through five ordered gates before reaching a tool handler:
+
+```
+MCP Client
+    |
+    | POST /mcp  Authorization: Bearer <jwt>
+    v
+RequestIdMiddleware          -- generates X-Request-Id UUID
+    |
+JWTAuthMiddleware            -- validates JWT: sig, iss, aud, exp, scope
+    |  401 if invalid
+    v
+ASGI context wrapper         -- maps JWT groups → role; builds ToolContext
+    |                           (looks up per-user PCE creds from keystore
+    |                            or uses shared env creds in shared mode)
+    v
+dispatcher (server.py)       -- enforces:
+    |    1. Role allowlist (ToolSpec.roles)
+    |    2. PCE-presence gate (ToolSpec.requires_pce)
+    |    3. Confirm-token requirement (ToolSpec.requires_confirm)
+    |    writes AuditEntry for every decision
+    v
+handler(ctx, arguments)      -- ctx.pce is ready; makes PCE API calls
+```
+
+---
+
+## Per-user mode (default)
+
+In `per_user` mode (`MCP_PCE_MODE=per_user`, the default), each authenticated user has their own PCE API key stored encrypted in a SQLite keystore. PCE-side audit logs attribute actions to the individual user.
+
+### Required env vars
+
+```bash
+# OAuth
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+export MCP_OAUTH_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+export MCP_OAUTH_JWKS_URL=https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+
+# Keystore
+export MCP_KEK=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+export MCP_KEYSTORE_PATH=/var/lib/illumio-mcp/keys.db
+
+# Confirm tokens
+export MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+
+# Role mapping
+export MCP_ROLE_GROUPS_ADMIN=sg-illumio-mcp-admin
+export MCP_ROLE_GROUPS_OPERATOR=sg-illumio-mcp-operator,sg-illumio-mcp-admin
+export MCP_ROLE_GROUPS_READER=sg-illumio-mcp-readonly,sg-illumio-mcp-operator,sg-illumio-mcp-admin
+
+# Start
+illumio-mcp-http --host 127.0.0.1 --port 8080
+```
+
+### User onboarding
+
+First-time users land in the `no_pce_credentials` state. Two paths:
+
+1. **Browser:** visit `https://mcp.illumio.example/setup` (after authenticating). Paste PCE host, port, org ID, API key, and API secret. The form writes encrypted credentials to the keystore.
+2. **MCP client:** call the `register-pce-credentials` tool. This is the only tool that works before credentials are registered. Note that pasting a secret into a chat transcript leaves it in the LLM's context window — the browser path is preferred from a security standpoint.
+
+After onboarding, all tools with the user's role become available immediately.
+
+---
+
+## Shared mode
+
+In `shared` mode (`MCP_PCE_MODE=shared`), all authenticated users share one PCE service-account key loaded from env. No keystore, no `/setup` page, no `MCP_KEK` required. JWT auth, role-based authz, audit log, and confirm tokens all still apply.
+
+The server-side audit log records per-human identity (`sub` from the JWT). PCE-side audit logs show only the service account.
+
+### Required env vars
+
+```bash
+# PCE service account (same vars stdio uses)
+export PCE_HOST=https://your-pce.example.com
+export PCE_PORT=8443
+export PCE_ORG_ID=1
+export API_KEY=service_account_key
+export API_SECRET=service_account_secret
+
+# OAuth (same as per-user)
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+export MCP_OAUTH_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+export MCP_OAUTH_JWKS_URL=https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+
+# Confirm tokens (required in auth mode)
+export MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+
+# Role mapping
+export MCP_ROLE_GROUPS_ADMIN=sg-illumio-mcp-admin
+export MCP_ROLE_GROUPS_OPERATOR=sg-illumio-mcp-operator
+
+# Mode
+export MCP_PCE_MODE=shared
+
+illumio-mcp-http --host 127.0.0.1 --port 8080
+```
+
+In shared mode:
+- `/setup` is not mounted.
+- `register-pce-credentials` and `delete-pce-credentials` return a `shared_mode` error message.
+- `check-pce-credentials-status` returns `{"registered": true, "mode": "shared", ...}`.
+
+---
+
+## Safety gates
+
+The server performs several checks at startup and at request time to prevent common misconfigurations:
+
+**Startup checks:**
+
+- `Refusing to bind '<host>' without MCP_DEV_INSECURE=1` — the server will not bind a non-loopback address unless `MCP_DEV_INSECURE=1` is set. Production deployments must put TLS termination at a reverse proxy and forward to `127.0.0.1`.
+- `Missing required OAuth env vars: MCP_OAUTH_ISSUER, ...` — lists every missing var so you can fix them all at once.
+- `MCP_KEK env var is required` — in per-user mode with auth enabled, the key-encryption-key must be present.
+- `MCP_PCE_MODE=shared requires PCE_HOST env var` — shared mode validates the PCE env vars at startup rather than at first request.
+
+**Request-time checks:**
+
+- A 401 with `WWW-Authenticate: Bearer resource_metadata="..."` means the JWT was missing, expired, or had the wrong issuer, audience, or signature.
+- A `forbidden_no_role` error means the user's JWT groups matched none of the configured `MCP_ROLE_GROUPS_*` lists.
+
+---
+
+## Health endpoints
+
+Both endpoints are always unauthenticated — no `Authorization` header required.
+
+- `GET /healthz` — liveness: `{"status": "ok"}`
+- `GET /readyz` — readiness: `{"status": "ready"}`
+
+---
+
+## Reverse-proxy guidance
+
+In production, terminate TLS at your load balancer or ingress controller and proxy to the MCP server on loopback:
+
+```
+Internet → HTTPS (your proxy/ingress) → HTTP http://127.0.0.1:8080
+```
+
+Required proxy configuration:
+- Pass the `Authorization` header through unchanged (do not strip it).
+- Do not cache responses to `/mcp` — the Streamable HTTP transport uses chunked SSE responses that must not be cached or buffered. Set `Cache-Control: no-store` and `X-Accel-Buffering: no` if using nginx.
+- Pass `X-Request-Id` through if your proxy sets it; the server respects it for trace correlation.
+
+---
+
+## Hybrid mode (future work)
+
+Phase 3f will add `MCP_PCE_MODE=hybrid`: users who have registered per-user credentials use them; others fall back to the shared service account. This allows teams to roll out shared mode for fast onboarding and let individual users opt in to per-user attribution later. See the [spec](../superpowers/specs/2026-05-12-phase-3f-hybrid-pce-mode-spec.md) for the design. Track via GitHub issue #17.

--- a/docs/operations/oauth-providers/auth0.md
+++ b/docs/operations/oauth-providers/auth0.md
@@ -1,0 +1,72 @@
+# Auth0 — OAuth Setup
+
+This is a briefer guide for Auth0. Verify steps with your IdP admin — Auth0's UI evolves frequently.
+
+---
+
+## Step 1: Create a Custom API
+
+1. In the Auth0 Dashboard, navigate to **Applications** → **APIs** → **Create API**.
+2. **Name:** `illumio-mcp`
+3. **Identifier (audience):** `https://mcp.illumio.example` — this becomes `MCP_OAUTH_AUDIENCE`.
+4. **Signing algorithm:** RS256.
+5. Click **Create**.
+
+---
+
+## Step 2: Enable RBAC and add permissions
+
+1. In the API settings, go to the **Settings** tab.
+2. Enable **RBAC** and **Add Permissions in the Access Token**.
+3. Go to the **Permissions** tab and add:
+   - **Permission:** `illumio-mcp.use`
+   - **Description:** `Access Illumio MCP Server`
+
+---
+
+## Step 3: Configure groups claim (verify with your IdP admin)
+
+Auth0 does not include groups/roles in access tokens by default. The recommended approach is to use Auth0 Actions or Rules to add a custom claim:
+
+1. Navigate to **Actions** → **Library** → **Build Custom Action** (or **Auth Pipeline** → **Rules** in the legacy interface).
+2. Add a Post-Login action that reads the user's app metadata or Auth0 roles and adds them to the access token under the `groups` or `roles` key:
+
+```javascript
+// Example Auth0 Action (verify syntax with your IdP admin)
+exports.onExecutePostLogin = async (event, api) => {
+  const roles = event.authorization?.roles || [];
+  api.accessToken.setCustomClaim('groups', roles);
+};
+```
+
+The exact approach (Actions vs Rules, custom claim namespace) depends on your Auth0 plan and configuration. Verify with your IdP admin.
+
+---
+
+## Step 4: Create Applications for MCP clients
+
+For each MCP client:
+
+1. **Applications** → **Create Application**.
+2. **Type:** Native (for Claude Desktop / Cursor) or Single Page Application (for MCP Inspector).
+3. **Allowed Callback URLs:** Set the redirect URI for the client.
+4. Under **APIs**, authorize the application to access your `illumio-mcp` API with the `illumio-mcp.use` scope.
+
+---
+
+## Step 5: Collect env vars
+
+```bash
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+export MCP_OAUTH_ISSUER=https://<your-auth0-domain>/
+export MCP_OAUTH_JWKS_URL=https://<your-auth0-domain>/.well-known/jwks.json
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+export MCP_OAUTH_REQUIRED_SCOPE=illumio-mcp.use
+
+# Role mapping — use role/group names as they appear in the token claim you configured
+export MCP_ROLE_GROUPS_ADMIN=illumio-admin
+export MCP_ROLE_GROUPS_OPERATOR=illumio-operator,illumio-admin
+export MCP_ROLE_GROUPS_READER=illumio-readonly,illumio-operator,illumio-admin
+```
+
+Note the trailing slash on the Auth0 issuer — this is required. Verify with your IdP admin.

--- a/docs/operations/oauth-providers/entra.md
+++ b/docs/operations/oauth-providers/entra.md
@@ -1,0 +1,113 @@
+# Microsoft Entra ID (Azure AD) — OAuth Setup
+
+This is the most-tested IdP integration. These instructions register the MCP server as a protected resource and configure MCP clients to authenticate against your Entra tenant.
+
+---
+
+## Step 1: Create an App Registration for the MCP server (the resource)
+
+This registration represents the MCP server itself — it is the OAuth resource.
+
+1. In the [Azure Portal](https://portal.azure.com), navigate to **Azure Active Directory** → **App registrations** → **New registration**.
+2. **Name:** `illumio-mcp-server` (or any meaningful name).
+3. **Supported account types:** Accounts in this organizational directory only (single tenant).
+4. **Redirect URI:** leave blank for now (the server registration does not need one).
+5. Click **Register**.
+
+Note the **Application (client) ID** and **Directory (tenant) ID** from the overview page.
+
+---
+
+## Step 2: Set the App ID URI
+
+The App ID URI becomes `MCP_OAUTH_AUDIENCE`.
+
+1. In the app registration, go to **Expose an API**.
+2. Next to **Application ID URI**, click **Set**.
+3. Accept the default (`api://<client-id>`) or set a custom URI such as `https://mcp.illumio.example`. Custom URIs must match your `MCP_PUBLIC_URL` domain.
+4. Click **Save**.
+
+---
+
+## Step 3: Expose the `illumio-mcp.use` scope
+
+1. Still in **Expose an API**, click **Add a scope**.
+2. **Scope name:** `illumio-mcp.use`
+3. **Who can consent:** Admins and users (or Admins only for enterprise policy).
+4. **Admin consent display name:** `Access Illumio MCP Server`
+5. **Admin consent description:** `Allows the app to call Illumio MCP tools on behalf of the user.`
+6. **State:** Enabled.
+7. Click **Add scope**.
+
+---
+
+## Step 4: Configure groups claim emission
+
+The server maps Entra security groups to MCP roles. Entra must include the user's group memberships in the access token.
+
+1. In the app registration, go to **Token configuration**.
+2. Click **Add groups claim**.
+3. Select **Security groups**.
+4. Under **Access token**, check the box for **Group ID** (Entra emits object IDs, not display names — you will use object IDs in `MCP_ROLE_GROUPS_*`).
+5. Click **Add**.
+
+**Note:** If a user is a member of more than ~200 groups, Entra omits the `groups` claim and instead sets `_claim_names: {"groups": "src1"}`. For large directories, use **App roles** instead of security groups (verify with your Entra admin). The server reads either the `groups` or `roles` claim.
+
+---
+
+## Step 5: Pre-register MCP client apps
+
+MCP clients (Claude Desktop, Cursor, MCP Inspector) must be registered as separate app registrations in your tenant. Open Dynamic Client Registration is typically disabled in enterprise Entra tenants.
+
+For each client, create a new app registration:
+
+### Claude Desktop
+
+1. **App registration name:** `illumio-mcp-claude-desktop`
+2. **Redirect URIs:** Add the platform **Mobile and desktop applications** and set URI to `http://localhost` (Claude Desktop uses a local redirect).
+3. **API permissions:** Click **Add a permission** → **My APIs** → select your `illumio-mcp-server` registration → check `illumio-mcp.use` → **Add permissions**.
+4. If your tenant requires admin consent, have an admin click **Grant admin consent** on the API permissions page.
+
+### MCP Inspector
+
+1. **App registration name:** `illumio-mcp-inspector`
+2. **Redirect URIs:** Single-page application, `http://localhost:6274/oauth/callback` (MCP Inspector's default PKCE callback).
+3. **API permissions:** Same as above — grant `illumio-mcp.use`.
+
+### Cursor
+
+Verify with your IdP admin — Cursor's redirect URI may differ by version. A common pattern is `http://localhost` with a dynamic port. Check Cursor's current MCP OAuth documentation for the exact values.
+
+---
+
+## Step 6: Collect env vars
+
+```bash
+# Tenant-specific JWKS endpoint
+TENANT_ID=<your-tenant-id>
+
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+export MCP_OAUTH_ISSUER=https://login.microsoftonline.com/${TENANT_ID}/v2.0
+export MCP_OAUTH_JWKS_URL=https://login.microsoftonline.com/${TENANT_ID}/discovery/v2.0/keys
+# Use the App ID URI from Step 2
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+# Or if you kept the default: api://<client-id>
+# export MCP_OAUTH_AUDIENCE=api://<application-client-id>
+export MCP_OAUTH_REQUIRED_SCOPE=illumio-mcp.use
+
+# Role mapping — use Entra group object IDs, not display names
+export MCP_ROLE_GROUPS_ADMIN=<object-id-of-sg-illumio-admin>
+export MCP_ROLE_GROUPS_OPERATOR=<object-id-of-sg-illumio-operator>,<object-id-of-sg-illumio-admin>
+export MCP_ROLE_GROUPS_READER=<object-id-of-sg-illumio-readonly>,<object-id-of-sg-illumio-operator>,<object-id-of-sg-illumio-admin>
+```
+
+Find group object IDs in **Azure Active Directory** → **Groups** → select the group → **Object ID**.
+
+---
+
+## Troubleshooting
+
+- **401 `iss mismatch`:** Ensure `MCP_OAUTH_ISSUER` exactly matches the `iss` claim in the access token. For Entra v2, the issuer is `https://login.microsoftonline.com/<tenant-id>/v2.0`. For v1, it omits `/v2.0`. Check which version your Entra is configured to issue.
+- **401 `aud mismatch`:** The `aud` claim in the token must exactly match `MCP_OAUTH_AUDIENCE`. Use a JWT decoder (e.g., jwt.io) to inspect the token.
+- **`forbidden_no_role`:** The user's groups are not in the token, or the group object IDs don't match what you set in `MCP_ROLE_GROUPS_*`. Decode the token and check the `groups` claim.
+- **Groups claim missing entirely:** The user has too many group memberships (>200). Switch to App Roles or use a nested group approach with fewer direct groups.

--- a/docs/operations/oauth-providers/keycloak.md
+++ b/docs/operations/oauth-providers/keycloak.md
@@ -1,0 +1,96 @@
+# Keycloak — OAuth Setup
+
+This is a briefer guide for self-hosted Keycloak. Verify steps with your Keycloak admin — versions vary.
+
+---
+
+## Step 1: Create or choose a Realm
+
+Use an existing realm or create a new one for the MCP server:
+
+1. In the Keycloak Admin Console, select the realm from the top-left dropdown (or create one under **Add realm**).
+2. Note the realm name — it appears in all endpoint URLs.
+
+---
+
+## Step 2: Create a Client (the resource server)
+
+1. Navigate to **Clients** → **Create Client**.
+2. **Client type:** OpenID Connect.
+3. **Client ID:** `illumio-mcp-server`.
+4. Click **Next**.
+5. **Client authentication:** Off (public client — the resource server does not need to authenticate to Keycloak; it only validates tokens).
+6. **Authorization:** Off.
+7. Click **Save**.
+
+---
+
+## Step 3: Configure the audience
+
+Keycloak access tokens include the `aud` claim as the client ID by default. Set `MCP_OAUTH_AUDIENCE=illumio-mcp-server` to match.
+
+Alternatively, add an **Audience mapper** to include a custom URI:
+
+1. In the client, go to **Client scopes** → **illumio-mcp-server-dedicated** → **Add mapper** → **By configuration** → **Audience**.
+2. **Name:** `mcp-audience`
+3. **Included Custom Audience:** `https://mcp.illumio.example`
+4. **Add to access token:** On.
+
+---
+
+## Step 4: Create a client scope for `illumio-mcp.use`
+
+1. Navigate to **Client Scopes** → **Create client scope**.
+2. **Name:** `illumio-mcp.use`
+3. **Type:** Optional.
+4. Click **Save**.
+5. Assign this scope to the MCP client registrations (see Step 6).
+
+---
+
+## Step 5: Add a groups mapper
+
+1. In the realm, go to **Client Scopes** → select a shared scope (or the dedicated scope for the MCP client) → **Mappers** → **Add mapper**.
+2. **Mapper type:** Group Membership.
+3. **Name:** `groups`
+4. **Token Claim Name:** `groups`
+5. **Full group path:** Off (emits bare group names, not `/path/to/group`).
+6. **Add to access token:** On.
+
+Verify with your Keycloak admin — the mapper configuration differs between Keycloak versions.
+
+---
+
+## Step 6: Register MCP client applications
+
+For each MCP client, create a new client registration in Keycloak:
+
+1. **Clients** → **Create Client**.
+2. **Client type:** OpenID Connect.
+3. **Client ID:** e.g., `illumio-mcp-claude-desktop`.
+4. **Authentication:** Off (PKCE flow).
+5. **Valid redirect URIs:** Set the client's redirect URI.
+6. In **Client scopes**, add `illumio-mcp.use` as a default or optional scope.
+
+---
+
+## Step 7: Collect env vars
+
+```bash
+REALM=your-realm-name
+KEYCLOAK_URL=https://keycloak.example.com
+
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+export MCP_OAUTH_ISSUER=${KEYCLOAK_URL}/realms/${REALM}
+export MCP_OAUTH_JWKS_URL=${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/certs
+# Use your custom audience URI or the client ID:
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+export MCP_OAUTH_REQUIRED_SCOPE=illumio-mcp.use
+
+# Role mapping — group names as they appear in the groups claim
+export MCP_ROLE_GROUPS_ADMIN=illumio-mcp-admin
+export MCP_ROLE_GROUPS_OPERATOR=illumio-mcp-operator,illumio-mcp-admin
+export MCP_ROLE_GROUPS_READER=illumio-mcp-readonly,illumio-mcp-operator,illumio-mcp-admin
+```
+
+Verify with your Keycloak admin — endpoint paths, realm-specific URLs, and group claim configuration vary across Keycloak versions and deployment types.

--- a/docs/operations/oauth-providers/okta.md
+++ b/docs/operations/oauth-providers/okta.md
@@ -1,0 +1,86 @@
+# Okta — OAuth Setup
+
+This guide sets up Okta as the Authorization Server for the MCP server. The approach uses a Custom Authorization Server (recommended over the Org AS for API access).
+
+These steps are best-effort — verify specifics with your Okta admin, as UI paths change across Okta releases.
+
+---
+
+## Step 1: Create a Custom Authorization Server
+
+1. In the Okta Admin Console, navigate to **Security** → **API** → **Authorization Servers**.
+2. Click **Add Authorization Server**.
+3. **Name:** `illumio-mcp`
+4. **Audience:** `https://mcp.illumio.example` (this becomes `MCP_OAUTH_AUDIENCE`)
+5. **Description:** `Illumio MCP Server resource`
+6. Click **Save**.
+
+Note the **Issuer URI** from the Authorization Server overview — it becomes `MCP_OAUTH_ISSUER`.
+
+---
+
+## Step 2: Add the `illumio-mcp.use` scope
+
+1. In the Authorization Server, go to the **Scopes** tab.
+2. Click **Add Scope**.
+3. **Name:** `illumio-mcp.use`
+4. **Display phrase:** `Access Illumio MCP Server`
+5. **User consent:** check if you want users to explicitly grant consent.
+6. Click **Create**.
+
+---
+
+## Step 3: Configure a groups claim
+
+The server reads the `groups` or `roles` claim from the access token to map users to MCP roles.
+
+1. In the Authorization Server, go to the **Claims** tab.
+2. Click **Add Claim**.
+3. **Name:** `groups`
+4. **Include in token type:** Access Token, Always.
+5. **Value type:** Groups
+6. **Filter:** Matches regex `.*` (all groups), or restrict to a specific prefix like `sg-illumio.*`.
+7. **Include in:** Any scope.
+8. Click **Create**.
+
+Verify with your Okta admin — the exact filter type (Starts with, Matches regex, Equals) depends on your group naming convention.
+
+---
+
+## Step 4: Create an OAuth Application for each MCP client
+
+For each MCP client (Claude Desktop, Cursor, MCP Inspector):
+
+1. Navigate to **Applications** → **Applications** → **Create App Integration**.
+2. **Sign-in method:** OIDC – OpenID Connect.
+3. **Application type:** Native Application (for desktop clients) or Single-Page Application (for browser-based tools like MCP Inspector).
+4. **Grant type:** Authorization Code with PKCE.
+5. **Sign-in redirect URIs:** Add the redirect URI for the specific client (e.g., `http://localhost` for Claude Desktop, `http://localhost:6274/oauth/callback` for MCP Inspector — verify with your IdP admin).
+6. Under **Assignments**, assign users or groups.
+
+---
+
+## Step 5: Collect env vars
+
+```bash
+export MCP_PUBLIC_URL=https://mcp.illumio.example
+# Issuer from the Authorization Server overview:
+export MCP_OAUTH_ISSUER=https://<your-okta-domain>/oauth2/<auth-server-id>
+# JWKS from the Authorization Server's metadata:
+export MCP_OAUTH_JWKS_URL=https://<your-okta-domain>/oauth2/<auth-server-id>/v1/keys
+export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+export MCP_OAUTH_REQUIRED_SCOPE=illumio-mcp.use
+
+# Role mapping — use Okta group names (not IDs) as they appear in the groups claim
+export MCP_ROLE_GROUPS_ADMIN=sg-illumio-mcp-admin
+export MCP_ROLE_GROUPS_OPERATOR=sg-illumio-mcp-operator,sg-illumio-mcp-admin
+export MCP_ROLE_GROUPS_READER=sg-illumio-mcp-readonly,sg-illumio-mcp-operator,sg-illumio-mcp-admin
+```
+
+---
+
+## Troubleshooting
+
+- **401 `iss mismatch`:** The `iss` in the token must exactly match `MCP_OAUTH_ISSUER`. For Custom AS, it includes the AS ID path segment; for the Org AS, it is just your Okta domain. Verify by decoding an access token.
+- **`groups` claim missing:** The claim was not added, or the scope filter excludes the user's groups. Check the claim policy under the Authorization Server.
+- Verify with your Okta admin if unsure about Application types, redirect URIs, or group filter syntax.

--- a/docs/operations/quickstart.md
+++ b/docs/operations/quickstart.md
@@ -1,0 +1,100 @@
+# Quickstart
+
+Three paths to a running server. Pick the one that matches your goal.
+
+---
+
+## 1. Stdio — no setup required
+
+The default mode. The MCP client launches the server as a subprocess. No network port, no auth.
+
+```bash
+# Clone and install
+git clone https://github.com/alexgoller/illumio-mcp-server.git
+cd illumio-mcp-server
+pip install -e .
+
+# Create .env with your PCE credentials
+cat > .env <<EOF
+PCE_HOST=https://your-pce.example.com
+PCE_PORT=8443
+PCE_ORG_ID=1
+API_KEY=your_api_key
+API_SECRET=your_api_secret
+EOF
+
+# Verify it works (Ctrl-C to stop)
+python -m illumio_mcp
+```
+
+Then add to Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "illumio-mcp": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/illumio-mcp-server", "run", "illumio-mcp"],
+      "env": {
+        "PCE_HOST": "https://your-pce.example.com",
+        "PCE_PORT": "8443",
+        "PCE_ORG_ID": "1",
+        "API_KEY": "your_api_key",
+        "API_SECRET": "your_api_secret"
+      }
+    }
+  }
+}
+```
+
+See [stdio-mode.md](stdio-mode.md) for the full Cursor config and Docker variants.
+
+---
+
+## 2. HTTP — dev-insecure (5 minutes)
+
+Use this for local integration testing with MCP Inspector or to verify the HTTP transport before wiring up OAuth.
+
+**Prerequisites:** `starlette`, `uvicorn`, and `mcp>=1.8.0` (installed automatically with `pip install -e .`).
+
+```bash
+# Start the server on localhost (refuses to bind 0.0.0.0 without this flag)
+MCP_DEV_INSECURE=1 illumio-mcp-http
+
+# Verify health
+curl http://127.0.0.1:8080/healthz
+# {"status":"ok"}
+```
+
+Point MCP Inspector at `http://127.0.0.1:8080/mcp` (transport: Streamable HTTP). All 46 tools are available with no auth check.
+
+The server logs a prominent warning:
+
+```
+MCP_DEV_INSECURE=1: HTTP server starting WITHOUT auth. Do not use in production.
+```
+
+Do not use this in production.
+
+---
+
+## 3. HTTP — production-shaped
+
+Production requires an OAuth IdP. The fastest path to production-shaped is:
+
+1. Set up your IdP (see [oauth-providers/entra.md](oauth-providers/entra.md) for Entra ID — the most-tested path).
+2. Generate secrets:
+   ```bash
+   export MCP_KEK=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+   export MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+   ```
+3. Set OAuth env vars and start:
+   ```bash
+   export MCP_PUBLIC_URL=https://mcp.illumio.example
+   export MCP_OAUTH_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+   export MCP_OAUTH_JWKS_URL=https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
+   export MCP_OAUTH_AUDIENCE=https://mcp.illumio.example
+   illumio-mcp-http --host 127.0.0.1 --port 8080
+   ```
+
+For the full picture — PCE mode, role mapping, audit log — see [http-mode.md](http-mode.md).

--- a/docs/operations/stdio-mode.md
+++ b/docs/operations/stdio-mode.md
@@ -1,0 +1,122 @@
+# Stdio Mode
+
+Stdio is the default transport. The MCP client launches the server as a subprocess over stdin/stdout. No network port opens, no auth is required — the OS user who launched the process is implicitly trusted.
+
+In stdio mode:
+- Roles do not apply (implicitly `admin`).
+- The audit log is not written (a `NullAuditLog` is used).
+- Confirm-token enforcement does not apply — mutating tools like `provision-policy` and `ringfence-batch` work without a token.
+- PCE credentials come from the `PCE_*` env vars (same as [shared HTTP mode](http-mode.md)).
+
+---
+
+## Running directly
+
+```bash
+# With .env file (recommended)
+python -m illumio_mcp
+
+# With explicit env
+PCE_HOST=https://pce.example.com PCE_PORT=8443 PCE_ORG_ID=1 \
+  API_KEY=mykey API_SECRET=mysecret python -m illumio_mcp
+```
+
+The server starts, logs `Starting stdio server` to `illumio-mcp.log`, and exits cleanly when stdin closes.
+
+---
+
+## Claude Desktop
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+### Using uv (recommended)
+
+```json
+{
+  "mcpServers": {
+    "illumio-mcp": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/path/to/illumio-mcp-server",
+        "run",
+        "illumio-mcp"
+      ],
+      "env": {
+        "PCE_HOST": "https://your-pce.example.com",
+        "PCE_PORT": "8443",
+        "PCE_ORG_ID": "1",
+        "API_KEY": "your_api_key",
+        "API_SECRET": "your_api_secret"
+      }
+    }
+  }
+}
+```
+
+### Using Docker
+
+```json
+{
+  "mcpServers": {
+    "illumio-mcp-docker": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--init", "--rm",
+        "--env-file", "/Users/YOUR_USERNAME/.illumio-mcp.env",
+        "ghcr.io/alexgoller/illumio-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+Where `~/.illumio-mcp.env` contains:
+```
+PCE_HOST=https://your-pce.example.com
+PCE_PORT=8443
+PCE_ORG_ID=1
+API_KEY=your_api_key
+API_SECRET=your_api_secret
+```
+
+---
+
+## Cursor
+
+In Cursor, add the server to your MCP configuration (Settings → MCP):
+
+```json
+{
+  "illumio-mcp": {
+    "command": "uv",
+    "args": [
+      "--directory",
+      "/path/to/illumio-mcp-server",
+      "run",
+      "illumio-mcp"
+    ],
+    "env": {
+      "PCE_HOST": "https://your-pce.example.com",
+      "PCE_PORT": "8443",
+      "PCE_ORG_ID": "1",
+      "API_KEY": "your_api_key",
+      "API_SECRET": "your_api_secret"
+    }
+  }
+}
+```
+
+---
+
+## TLS verification
+
+Set `PCE_TLS_VERIFY=false` to disable TLS certificate verification for PCE instances with self-signed certificates. Do not disable TLS verification in production environments with trusted certificates.
+
+```json
+"env": {
+  "PCE_TLS_VERIFY": "false",
+  ...
+}
+```

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,169 @@
+# Troubleshooting
+
+Common errors, what they mean, and how to fix them.
+
+---
+
+## 401 with `WWW-Authenticate: Bearer resource_metadata=...`
+
+**What it means:** The request to `/mcp` was rejected because the JWT was missing, malformed, expired, or had the wrong issuer, audience, or scope.
+
+The `WWW-Authenticate` header points to `/.well-known/oauth-protected-resource`, which tells spec-compliant MCP clients where to find the Authorization Server and run PKCE auth code flow.
+
+**How to diagnose:**
+
+1. Decode the JWT at [jwt.io](https://jwt.io) and check:
+   - `iss` matches `MCP_OAUTH_ISSUER` exactly (including the trailing `/v2.0` for Entra).
+   - `aud` matches `MCP_OAUTH_AUDIENCE` exactly.
+   - `exp` has not passed.
+   - `scope` or `scp` contains `illumio-mcp.use` (or your configured `MCP_OAUTH_REQUIRED_SCOPE`).
+2. Verify the server can reach the JWKS URL:
+   ```bash
+   curl -s $MCP_OAUTH_JWKS_URL | python -m json.tool | head -20
+   ```
+3. Check server logs for `InvalidTokenError` messages, which include a short reason code (`iss mismatch`, `aud mismatch`, `exp passed`, `missing required scope`, etc.).
+
+---
+
+## `forbidden_no_role`
+
+**What it means:** The JWT is valid, but the user's groups (from the `groups` or `roles` claim) do not match any of the configured `MCP_ROLE_GROUPS_*` lists, and `MCP_ROLE_DEFAULT` is not set.
+
+**How to fix:**
+
+1. Decode the JWT and inspect the `groups` (Entra) or `roles` (Okta) claim. Copy one of the group values.
+2. Check that the value exactly matches a group in `MCP_ROLE_GROUPS_READER`, `MCP_ROLE_GROUPS_OPERATOR`, or `MCP_ROLE_GROUPS_ADMIN`.
+   - For Entra: you configured object IDs, not display names. Make sure you used the group's object ID, not its `cn` or display name.
+3. If the user should have read access and no group-based provisioning is available yet, set `MCP_ROLE_DEFAULT=reader` as a temporary fallback.
+
+---
+
+## `forbidden`
+
+**What it means:** The user has a role, but that role is not in the `roles=` allowlist for the tool they called. For example, a `reader` calling `create-workload` (which requires `operator` or `admin`).
+
+**How to fix:** Either provision the user into a higher role group, or check that the tool's role metadata in `TOOL_REGISTRY` is correct for your use case.
+
+---
+
+## `no_pce_credentials`
+
+**What it means (per-user mode only):** The authenticated user has no PCE credentials registered in the keystore. This is the expected state for new users who have not yet onboarded.
+
+**How to fix:**
+
+1. Direct the user to visit `https://<mcp-server>/setup` to register their PCE API key via the browser form.
+2. Alternatively, the user can call the `register-pce-credentials` MCP tool — it is the only tool available in this state.
+
+In shared mode, this error never appears (the shared service account is always available).
+
+---
+
+## `confirm_required`
+
+**What it means:** The tool requires a single-use confirm token (it is marked `requires_confirm=True` in `TOOL_REGISTRY`). Currently: `provision-policy` and `ringfence-batch`.
+
+**How to fix:**
+
+1. The tool response includes a `params_hash` field (SHA-256 of canonical parameters).
+2. Call `POST /confirm` with the JWT and the params_hash:
+   ```bash
+   curl -X POST https://mcp.illumio.example/confirm \
+     -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     -d '{"tool": "provision-policy", "params_hash": "<sha256-from-error>"}'
+   # Response: {"confirm_token": "...", "expires_in": 120}
+   ```
+3. Re-call the tool with the token in `params._meta.confirm_token`.
+
+Tokens expire in 120 seconds by default (configurable via `MCP_CONFIRM_TTL_SECONDS`).
+
+---
+
+## `confirm_token_replay`
+
+**What it means:** The confirm token has already been used. Confirm tokens are single-use to prevent prompt-injection replay attacks.
+
+**How to fix:** Mint a fresh token via `POST /confirm` and re-call the tool immediately.
+
+---
+
+## `MCP_KEK env var is required`
+
+**What it means:** The server is starting in per-user HTTP mode (auth enabled, `MCP_PCE_MODE=per_user`) but `MCP_KEK` is not set. The server refuses to start because without a Key-Encryption-Key, it cannot decrypt stored per-user credentials.
+
+**How to fix:**
+
+```bash
+export MCP_KEK=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+```
+
+Store this value securely — in KMS, Vault, or your deployment secrets manager. If you lose the KEK, all per-user PCE credentials stored in the keystore are permanently unrecoverable.
+
+In shared mode (`MCP_PCE_MODE=shared`), `MCP_KEK` is not required.
+
+---
+
+## `Refusing to bind '0.0.0.0' without MCP_DEV_INSECURE=1`
+
+**What it means:** The server refused to start because you attempted to bind a non-loopback address (`0.0.0.0`, a public IP, etc.) without explicitly opting in with `MCP_DEV_INSECURE=1`.
+
+**Why this gate exists:** In dev-insecure mode there is no authentication. Accidentally binding `0.0.0.0` in dev-insecure mode would expose the server without auth to anyone on the network.
+
+**In production:** Do not bind `0.0.0.0` directly. Instead, bind `127.0.0.1` and put a TLS-terminating reverse proxy in front:
+
+```bash
+illumio-mcp-http --host 127.0.0.1 --port 8080
+# Reverse proxy handles TLS and forwards to 127.0.0.1:8080
+```
+
+**For local dev testing only:** If you genuinely need to expose the server on a network interface without auth (for example, to test from another machine in a lab), set `MCP_DEV_INSECURE=1`. This is not safe for production.
+
+---
+
+## Tests pass on `main` but fail with PCE
+
+The integration test suite (`tests/test_mcp_tools.py`) requires a real PCE. Tests are skipped or fail if the PCE env vars are missing or incorrect.
+
+**Checklist:**
+
+1. Verify `.env` exists and contains correct values:
+   ```bash
+   cat .env
+   ```
+2. Verify the test runner loads `.env`:
+   ```bash
+   grep -r "dotenv" tests/conftest.py src/
+   ```
+3. Test PCE connectivity directly:
+   ```bash
+   python -c "from illumio_mcp.pce import get_pce_from_env; pce = get_pce_from_env(); print(pce)"
+   ```
+4. Run only the PCE-free unit tests to isolate the issue:
+   ```bash
+   pytest tests/test_auth_*.py tests/test_context.py tests/test_registry.py tests/test_pce_builder.py tests/test_tool_metadata.py -v
+   ```
+
+---
+
+## `MCP_CONFIRM_HMAC_KEY env var is required`
+
+**What it means:** The server is starting in HTTP auth mode but `MCP_CONFIRM_HMAC_KEY` is not set. The confirm-token system requires an HMAC key to sign tokens.
+
+**How to fix:**
+
+```bash
+export MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')
+```
+
+---
+
+## Server starts but clients cannot connect
+
+1. Verify the server is listening:
+   ```bash
+   curl http://127.0.0.1:8080/healthz
+   ```
+2. If using a reverse proxy, verify the proxy passes the `Authorization` header and does not cache `/mcp` responses.
+3. Check that the MCP client is using transport type "Streamable HTTP" (not the deprecated SSE transport).
+4. Check `illumio-mcp.log` for startup errors.

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -1,0 +1,110 @@
+# Security Architecture
+
+## Five-layer defense
+
+Every tool call on the HTTP transport passes through five ordered gates. Failing any gate aborts the call and records an audit entry. Stdio mode skips layers 1–5 (the operator who launched the process is implicitly trusted as admin).
+
+```
+Layer 1: JWT validation
+  Checks: signature (RS256/ES256 against JWKS), iss == MCP_OAUTH_ISSUER,
+          aud == MCP_OAUTH_AUDIENCE, exp not past, nbf not future,
+          scope contains MCP_OAUTH_REQUIRED_SCOPE (default: illumio-mcp.use)
+  Failure: 401 with WWW-Authenticate: Bearer resource_metadata="..."
+  Implementation: auth/jwt_validator.py JWTValidator.validate()
+
+Layer 2: Role mapping
+  Maps JWT groups/roles claim to {reader, operator, admin} using
+  MCP_ROLE_GROUPS_{ADMIN,OPERATOR,READER}. Highest-matching role wins.
+  MCP_ROLE_DEFAULT is a fallback if no group matches.
+  Failure: denied, reason=forbidden_no_role
+  Implementation: auth/roles.py map_user_role()
+
+Layer 3: Per-tool role allowlist
+  Each tool has explicit roles= in TOOL_REGISTRY (tools/__init__.py).
+  Default-deny: a new tool without roles= fails at import time.
+  Failure: denied, reason=forbidden
+  Implementation: registry.py ToolSpec.roles, enforced in server.py dispatcher
+
+Layer 4: PCE-presence gate
+  Tools with requires_pce=True (the default) need ctx.pce to be non-None.
+  In per_user mode, ctx.pce is None until the user registers credentials.
+  Credential-management tools (register-pce-credentials etc.) have
+  requires_pce=False and are always callable.
+  Failure: denied, reason=no_pce_credentials
+  Implementation: registry.py ToolSpec.requires_pce, enforced in server.py dispatcher
+
+Layer 5: Confirm-token requirement
+  Tools with requires_confirm=True (provision-policy, ringfence-batch) require
+  a server-issued HMAC-SHA256 token in params._meta.confirm_token. Tokens are
+  single-use (jti tracked in SQLite), scoped to (sub, tool, params_hash), and
+  expire in MCP_CONFIRM_TTL_SECONDS (default 120s).
+  Failure: denied, reason=confirm_required | invalid_confirm_token | confirm_token_replay
+  Implementation: auth/confirm.py, auth/confirm_replay.py, transport/confirm_endpoint.py
+```
+
+---
+
+## Cryptography choices
+
+### Per-user keystore: AES-256-GCM envelope encryption
+
+Each user's PCE API key and secret are stored with two-tier envelope encryption:
+
+```
+MCP_KEK (32 bytes, from env/KMS)
+    |
+    | AES-256-GCM (nonce: 12 bytes)
+    v
+Data Key (DK, 32 bytes, fresh per-record)
+    |
+    | AES-256-GCM (nonce: 12 bytes, AAD: "sub|iss")
+    v
+Encrypted payload (api_key_enc or api_secret_enc)
+```
+
+Wire format per blob: `nonce_dk(12) || dk_ciphertext(48) || nonce_payload(12) || payload_ciphertext(N+16)`.
+
+The Additional Authentication Data (`sub|iss`) binds the ciphertext to its database row. If a ciphertext is copied to a different row, decryption fails — the AEAD tag will not verify.
+
+Source: `src/illumio_mcp/auth/crypto.py`
+
+### Confirm tokens: HMAC-SHA256
+
+Token format: `<base64url(payload_json)>.<base64url(hmac_sha256)>`
+
+Payload fields: `{sub, tool, params_hash, jti, exp}`. The HMAC covers the full payload. Any tampering (wrong sub, wrong tool, different params) invalidates the signature. Single-use is enforced by recording the `jti` in a SQLite table on first use.
+
+Source: `src/illumio_mcp/auth/confirm.py`
+
+### JWT validation: RS256/ES256 against JWKS
+
+PyJWT's `PyJWKClient` fetches and caches the IdP's JWKS. The cache is refreshed on `kid` mismatch (key rotation). Supported algorithms: RS256, ES256. Token validation is local — no per-request calls to the IdP.
+
+Source: `src/illumio_mcp/auth/jwt_validator.py`
+
+---
+
+## What is stored where
+
+| Data | Location | Permissions | Notes |
+|---|---|---|---|
+| KEK | Process env only (`MCP_KEK`) | Never persisted | Loss = total keystore loss (intentional) |
+| Per-user PCE creds (encrypted) | `MCP_KEYSTORE_PATH` SQLite (default `./data/keys.db`) | `chmod 600`, `umask 077` on create | Decryptable only with KEK |
+| Audit log | `MCP_AUDIT_LOG_PATH` SQLite (default `./data/audit.db`) | `chmod 600`, `umask 077` on create | No secrets; safe to ship to SIEM |
+| JTI replay store | `MCP_CONFIRM_JTI_PATH` SQLite (default alongside keystore) | `chmod 600`, `umask 077` on create | Used JTI values only; expires with TTL |
+| HMAC key | Process env only (`MCP_CONFIRM_HMAC_KEY`) | Never persisted | Rotation invalidates outstanding tokens |
+| IdP JWKS | In-process cache only | Never persisted | Auto-refreshed on key rotation |
+
+The SQLite files are created with `os.umask(0o077)` before `sqlite3.connect()` and then `os.chmod(path, 0o600)`. This means they are readable and writable only by the process owner on POSIX systems.
+
+---
+
+## Unauthenticated endpoints
+
+These endpoints intentionally require no `Authorization` header:
+
+- `GET /healthz` — liveness check
+- `GET /readyz` — readiness check
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 PRM document (tells clients where the AS is)
+
+All other endpoints (including `/setup` and `/confirm`) are protected by `JWTAuthMiddleware`.

--- a/docs/security/secret-management.md
+++ b/docs/security/secret-management.md
@@ -1,0 +1,142 @@
+# Secret Management
+
+How each secret should be generated, stored, and rotated.
+
+---
+
+## `MCP_KEK` — Key-Encryption-Key
+
+**What it protects:** All per-user PCE API keys and secrets stored in the keystore SQLite database. Without the KEK, the database is unreadable.
+
+**Generate:**
+
+```bash
+python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())'
+```
+
+This produces a 32-byte (256-bit) base64-encoded key, e.g.:
+`7K9mLqR3XpWvNzYeHcJbFdUsGtAiOk1s2PlMnQrEhVyw4BxCuDf5T6gZ8jO0sIA=`
+
+**Store:**
+- Development: in `.env` (never committed).
+- Production: in AWS KMS, HashiCorp Vault, Azure Key Vault, or a Kubernetes Secret with appropriate RBAC. The KEK value should never appear in version control or logs.
+- The server reads it from the process environment as a base64 string. Inject it from your secrets manager at deploy time.
+
+**Rotate:**
+
+KEK rotation re-wraps data keys without re-encrypting the payloads:
+
+1. Generate a new KEK.
+2. For each row in `user_pce_credentials`: decrypt the old `api_key_enc` and `api_secret_enc` using the old KEK, re-encrypt with the new KEK.
+3. Update the env var (`MCP_KEK`) to the new value.
+4. Restart the server.
+
+Step 2 is not yet implemented as a built-in command (future work). For now, perform it with a migration script using the `EnvelopeCipher` class from `src/illumio_mcp/auth/crypto.py`:
+
+```python
+from illumio_mcp.auth.crypto import EnvelopeCipher, load_kek_from_env
+import base64, os, sqlite3
+
+old_kek = base64.b64decode(os.environ["OLD_MCP_KEK"])
+new_kek = base64.b64decode(os.environ["NEW_MCP_KEK"])
+old_cipher = EnvelopeCipher(old_kek)
+new_cipher = EnvelopeCipher(new_kek)
+
+with sqlite3.connect("./data/keys.db") as con:
+    rows = con.execute("SELECT sub, iss, api_key_enc, api_secret_enc FROM user_pce_credentials").fetchall()
+    for sub, iss, api_key_enc, api_secret_enc in rows:
+        aad = f"{sub}|{iss}".encode()
+        ak = old_cipher.decrypt(api_key_enc, aad=aad)
+        ase = old_cipher.decrypt(api_secret_enc, aad=aad)
+        new_ak_enc = new_cipher.encrypt(ak, aad=aad)
+        new_ase_enc = new_cipher.encrypt(ase, aad=aad)
+        con.execute(
+            "UPDATE user_pce_credentials SET api_key_enc=?, api_secret_enc=? WHERE sub=? AND iss=?",
+            (new_ak_enc, new_ase_enc, sub, iss),
+        )
+```
+
+**Loss consequence:** All per-user PCE credentials become permanently unrecoverable. Users must re-register. This is intentional (fail-closed).
+
+---
+
+## `MCP_CONFIRM_HMAC_KEY` — Confirm token signing key
+
+**What it protects:** The integrity of confirm tokens. An attacker who knows this key could mint valid confirm tokens for any user and tool.
+
+**Generate:**
+
+```bash
+python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())'
+```
+
+**Store:** Same guidance as `MCP_KEK` — secrets manager, never in version control.
+
+**Rotate:**
+
+1. Generate a new HMAC key.
+2. Update the env var (`MCP_CONFIRM_HMAC_KEY`) to the new value.
+3. Restart the server.
+
+**Effect of rotation:** All outstanding confirm tokens (those minted with the old key) become immediately invalid. Users in the middle of a multi-step operation will need to mint a new token. Because tokens expire in `MCP_CONFIRM_TTL_SECONDS` (default 120s), the impact window is small.
+
+---
+
+## `API_KEY` / `API_SECRET` — Shared PCE service account credentials
+
+Used in stdio mode and HTTP shared mode (`MCP_PCE_MODE=shared`).
+
+**Rotation in shared mode:**
+
+1. Generate a new PCE API key for the service account in the PCE admin UI.
+2. Update `API_KEY` and `API_SECRET` in the env.
+3. Restart the HTTP server. The new credentials take effect immediately — the `get_pce_from_env()` function re-reads env vars on the next restart (it caches after first call within a process lifetime).
+4. Delete the old PCE API key from the PCE admin UI.
+
+**Rotation in stdio mode:** Same steps; each MCP client process will pick up the new credentials on next launch.
+
+---
+
+## Per-user PCE credentials (keystore)
+
+Each user's PCE API key and secret are stored encrypted in the keystore. Users manage their own credentials.
+
+**Self-service rotation:**
+
+1. Generate a new PCE API key in the PCE admin UI.
+2. Call `register-pce-credentials` with the new values — it overwrites the existing row (using SQLite `INSERT ... ON CONFLICT DO UPDATE`).
+3. Or visit `/setup` and submit the new values.
+
+The old PCE API key can then be deleted from the PCE admin UI.
+
+**Admin-forced rotation:**
+
+An admin can delete a specific user's credentials by calling `delete-pce-credentials` (requires `admin` role) or by direct SQLite manipulation:
+
+```sql
+DELETE FROM user_pce_credentials WHERE sub = '<user-sub-from-idp>';
+```
+
+After deletion, the user's next tool call will return `no_pce_credentials` and they will need to re-register.
+
+---
+
+## Audit log — what to ship to SIEM
+
+The audit log contains no secrets (tool arguments are not logged, PCE credentials are never logged). It is safe to ship to your SIEM without further redaction.
+
+Sensitive columns that ARE present:
+- `sub` — the IdP subject identifier (a user ID, not a display name). Map to display names in your SIEM using IdP directory data.
+
+Ship strategy: see the [Audit Log operations guide](../operations/audit-log.md) for Fluent Bit and cron-based options.
+
+---
+
+## Generate all secrets at once
+
+```bash
+echo "MCP_KEK=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')"
+echo "MCP_CONFIRM_HMAC_KEY=$(python -c 'import os, base64; print(base64.b64encode(os.urandom(32)).decode())')"
+```
+
+Store the output immediately in your secrets manager. Do not save it to a shell history or a text file.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,71 @@
+# Threat Model
+
+What the Phase 1-3e design protects against, what it does not protect against, and the honest trade-offs operators need to understand before deploying.
+
+---
+
+## Threats mitigated
+
+**Lost or stolen JWT (single user)**
+
+If a user's access token is stolen, the attacker can call the MCP server until the token expires. Mitigation: the IdP can revoke the user's session (force a re-auth on the next token refresh). Token lifetime (`exp`) limits the exposure window. Setting `MCP_CONFIRM_FRESH_AUTH_SECONDS` for confirm-token operations forces a re-authentication before any destructive action, reducing the window further.
+
+**Server compromise — encrypted credentials at rest**
+
+If an attacker obtains the keystore database file (`keys.db`) without also obtaining `MCP_KEK`, the per-user PCE credentials are unreadable. The AES-256-GCM envelope encryption means the database file alone is not sufficient for decryption. `MCP_KEK` must be stored separately from the database (e.g., in KMS).
+
+**Unauthenticated tool list discovery**
+
+An unauthenticated client cannot enumerate MCP tools. `POST /mcp` without a valid `Authorization` header returns `401` with a `WWW-Authenticate` pointer to the PRM document — it does not reveal the tool list, server version, or any PCE details.
+
+**Prompt injection forcing a destructive action**
+
+The confirm-token requirement for `provision-policy` and `ringfence-batch` forces a synchronous human-in-the-loop step that the LLM cannot execute autonomously. Even if a malicious payload in a PCE traffic-flow description convinces the LLM to call `provision-policy`, the LLM cannot mint the confirm token — that requires a separately authenticated HTTP request to `POST /confirm`. With `MCP_CONFIRM_FRESH_AUTH_SECONDS` set, it also requires a recent re-authentication.
+
+**Replay of a used confirm token**
+
+Each confirm token's `jti` is recorded in the `used_jti` SQLite table on first use. A replay attempt returns `confirm_token_replay` before the token is consumed again.
+
+---
+
+## Risks and accepted trade-offs
+
+**Lost `MCP_KEK` = total keystore loss**
+
+This is intentional. The KEK must not be stored next to the database, so there is no recovery path if it is lost. Operators MUST store `MCP_KEK` in a durable secrets manager (KMS, Vault) before deploying in per-user mode. This is the "fail closed" design: a lost KEK is better than a KEK stored in a recoverable location that an attacker could find.
+
+**Server compromise + KEK exfiltration = all per-user PCE keys readable**
+
+If an attacker compromises the server process AND extracts `MCP_KEK` (from process memory or env), they can decrypt all stored per-user PCE credentials. The envelope encryption protects the database file at rest but does not protect against a fully-compromised process. Mitigations: minimize the attack surface of the server process, use KMS-backed KEK (so the plaintext KEK never leaves the KMS boundary), rotate PCE API keys on a schedule.
+
+**No in-handler authz fallback**
+
+The dispatcher enforces role, PCE-presence, and confirm-token checks before calling a handler. Handlers themselves do not re-check these. If a bug bypasses the dispatcher (e.g., via a future refactor that introduces a direct handler call path), handlers will execute without authz enforcement. Currently no such path exists, but it is a risk to be aware of in code review.
+
+**Shared mode: server compromise = full PCE control as service account**
+
+In `MCP_PCE_MODE=shared`, all authenticated users operate as the PCE service account. A server compromise gives the attacker full PCE API access as that service account. This is the same risk profile as the original stdio-only deployment, but now the service account is exposed over a network. Mitigate by: using a service account with minimal PCE RBAC permissions, rotating the PCE API key on a schedule, and preferring per-user mode where feasible.
+
+**Streamable HTTP transport is not proxy-cache-safe**
+
+`/mcp` responses use chunked SSE (server-sent events) for streaming tool results. Reverse proxies that buffer or cache SSE streams will break the protocol. Ensure your proxy sets `X-Accel-Buffering: no` (nginx) or equivalent, and does not apply response caching to `/mcp`. The RFC 9728 PRM endpoint (`/.well-known/oauth-protected-resource`) can be cached normally.
+
+**MCP transport-level encryption is the proxy's responsibility**
+
+The server binds HTTP only. TLS must be terminated at the reverse proxy. Running the server directly on a public network without TLS is insecure and is blocked by the loopback-only gate (which requires `MCP_DEV_INSECURE=1` to override).
+
+---
+
+## Out of scope
+
+**Compromised IdP signing key**
+
+If an attacker obtains the IdP's private signing key, they can forge JWTs that pass the server's validation. This is the IdP's security responsibility, not ours. We validate tokens against the JWKS endpoint; if the JWKS is poisoned, our validation is bypassed. Mitigate at the IdP level (short key rotation schedules, HSM-backed keys, JWKS endpoint integrity monitoring).
+
+**PCE-side API vulnerabilities**
+
+The MCP server is an API client to the PCE. Bugs in the PCE's API or authentication are out of scope. We use the `python-illumio` SDK and assume the PCE API is correctly implemented.
+
+**Supply-chain attacks on Python dependencies**
+
+No special mitigations beyond standard practice (pinned lockfile, private PyPI mirror). This is an operational concern for the deploying team.

--- a/docs/superpowers/specs/2026-05-12-phase-3f-hybrid-pce-mode-spec.md
+++ b/docs/superpowers/specs/2026-05-12-phase-3f-hybrid-pce-mode-spec.md
@@ -1,0 +1,122 @@
+# Phase 3f: Hybrid PCE Mode — Design Spec
+
+**Status:** Backlog (feature request — not yet planned for implementation)
+**Date:** 2026-05-12
+**Depends on:** Phase 3b (per-user keystore) + Phase 3e (shared mode)
+**GitHub issue:** _(linked when filed)_
+
+---
+
+## Problem
+
+Phase 3b and Phase 3e introduced two PCE-credential modes that are mutually
+exclusive at startup:
+
+- `per_user` — every user must register their own PCE API key before any tool call works
+- `shared` — every user uses the same operator-configured service-account key
+
+Both have legitimate use cases, and some operators have asked for both at once:
+
+- A team rolls out the MCP server in **shared** mode for fast onboarding
+- A handful of senior engineers later want **per-user** PCE keys so PCE-side
+  audit logs attribute actions to them by name
+- Casual users keep getting "free" access through the shared key
+
+Today they have to pick one and live with it. **Hybrid mode** lets the same
+deployment serve both populations from one process.
+
+## Proposed behavior
+
+A new `MCP_PCE_MODE=hybrid` value:
+
+| User has registered per-user creds? | What `ctx.pce` is built from |
+|---|---|
+| Yes | The user's encrypted creds in the keystore (per-user mode behavior) |
+| No  | The env-loaded shared service account (shared mode behavior) |
+
+Tool behavior in hybrid mode:
+
+- **`/setup` is mounted** (users can opt into per-user attribution)
+- **`register-pce-credentials`** works (writes to keystore, switches that user to per-user PCE)
+- **`delete-pce-credentials`** works (drops them back to shared)
+- **`check-pce-credentials-status`** returns one of:
+  - `{"registered": true, "mode": "per_user", "pce_host": ..., ...}` — user has their own key
+  - `{"registered": true, "mode": "shared", "message": "Using shared service account; call register-pce-credentials to opt into per-user attribution."}` — user falls back to shared
+
+The dispatcher's `no_pce_credentials` gate **never fires** in hybrid mode — the
+shared key is always available as a fallback.
+
+## Why hybrid is non-trivial
+
+Looks like a one-line `if pce is None: pce = get_pce_from_env()` — and it
+mostly is — but there are real concerns the implementation must address:
+
+1. **PCE-side audit ambiguity.** Some calls show up as the human, some as
+   the service account. Whoever reads PCE audit needs to know this is by
+   design, not a bug. Document loudly.
+
+2. **Confused-deputy risk.** A user might *think* they're calling PCE as
+   themselves but is actually using the shared key (because their stored key
+   expired and silently fell back). Mitigation: `check-pce-credentials-status`
+   should expose the *current* effective mode, and we should consider logging
+   a per-call audit field `effective_pce_mode`.
+
+3. **Audit-log schema bump.** Add `effective_pce_mode` column so operators can
+   filter the audit log by which PCE creds were used: helpful for compliance
+   reviews ("show me everything alice did with the shared key vs her own").
+
+4. **Reading the shared key in hybrid mode requires the env vars.** Same
+   refusal-to-start logic as Phase 3e: `MCP_PCE_MODE=hybrid` requires both
+   `MCP_KEK` (for the keystore) AND `PCE_HOST`/`API_KEY`/`API_SECRET`
+   (for the shared fallback). Failing fast saves a confusing runtime error.
+
+## Sketch of implementation effort (when this is greenlit)
+
+Approximately 5 tasks, roughly 1 day of work:
+
+1. `auth/pce_mode.py` — add `HYBRID` constant, update `_VALID`, add
+   `is_hybrid_mode()` helper.
+2. `server.py` — `build_http_context_for` honors hybrid: per-user lookup
+   first, then env-loaded fallback. Audit-log entry includes
+   `effective_pce_mode` (`per_user` or `shared`).
+3. `auth/audit.py` — add `effective_pce_mode` column to `audit_log` schema +
+   a non-breaking migration.
+4. `tools/credentials.py` — `check-pce-credentials-status` reports the
+   current effective mode for the calling user; `register`/`delete` work as
+   in per-user mode.
+5. `transport/http.py` — load both `MCP_KEK` and `PCE_*` env in hybrid mode;
+   mount `/setup` route.
+6. Tests + README + PR.
+
+The architecture from Phase 3 makes this clean: every authz layer (JWT,
+role, audit, confirm) is independent of the PCE-credential source.
+
+## When to build this
+
+Don't build it speculatively. Triggers that justify shipping it:
+
+- An operator has actually asked for it (not just a hypothetical)
+- A team is using shared mode and wants a stepwise migration to per-user
+- Compliance requires named attribution for a subset of users without
+  forcing every user to onboard
+
+Until one of those fires, leaving it as a documented spec is the right call.
+
+## Decisions made up front (so future-us doesn't have to)
+
+- Default behavior when key store has no row: **fall through to shared**, not
+  refuse. Consistent with the "hybrid = best of both" promise.
+- Keystore row removal is allowed (delete tool works) — it cleanly drops
+  the user back to shared.
+- `check-pce-credentials-status` reports the effective state as it would
+  apply to the next tool call, not just whether a row exists.
+- `MCP_PCE_MODE` is still resolved once at startup; you cannot switch a
+  running process between hybrid and shared.
+
+## Out of scope for this spec
+
+- Per-user role overrides (Phase 3c handles role mapping; that's separate)
+- Per-tool mode override (no use case yet for "this specific tool always
+  uses the shared key even if the user has their own")
+- Read-only fallback (some users could be allowed shared for reads but
+  required to use their own key for writes — not asked for)


### PR DESCRIPTION
## Summary

Comprehensive documentation for the Phase 1–3e rollout, organized by audience (operators, security reviewers, contributors). Plus the Phase 3f hybrid-mode spec as a backlog item linked to issue #17.

> **Stacked on #16 (Phase 3e).** When #16 merges, base auto-updates.

## What's in here (16 docs)

**Operations (10 files):**
- `docs/operations/quickstart.md` — three-path getting-started (stdio, HTTP-dev, HTTP-prod)
- `docs/operations/configuration.md` — every env var in one table
- `docs/operations/stdio-mode.md` — Claude Desktop, Cursor, Docker
- `docs/operations/http-mode.md` — both PCE modes + safety gates
- `docs/operations/oauth-providers/{entra,okta,auth0,keycloak}.md`
- `docs/operations/audit-log.md` — schema + sample queries + SIEM shipping
- `docs/operations/troubleshooting.md` — 9 named errors with cause/fix

**Security (3 files):**
- `docs/security/architecture.md` — five-layer defense diagram
- `docs/security/threat-model.md` — what's mitigated vs accepted
- `docs/security/secret-management.md` — KEK/HMAC/PCE rotation

**Development (3 files):**
- `docs/development/code-layout.md` — package tree + dispatch flow
- `docs/development/adding-a-tool.md` — 5-step recipe with worked example
- `docs/development/testing.md` — three-tier test strategy + in-process JWT pattern

**Backlog spec:**
- `docs/superpowers/specs/2026-05-12-phase-3f-hybrid-pce-mode-spec.md` (linked from issue #17)

## Caveats from the doc-writing pass

- Entra recipe is the fully-tested OAuth path; Okta/Auth0/Keycloak recipes mark uncertain UI steps as "verify with your IdP admin" rather than fabricating
- KEK rotation is documented as a manual snippet; a `rotate-kek` CLI command is future work

🤖 Generated with [Claude Code](https://claude.com/claude-code)